### PR TITLE
Added an extensible set() for header extensions

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1797,9 +1797,9 @@ def CheckHeaderFileIncluded(filename, include_state, error):
   for ext in _header_extensions:
       headerfile = filename[0:len(filename) - 2] + ext
       if not os.path.exists(headerfile):
-        return
+        continue
       headername = FileInfo(headerfile).RepositoryName()
-      first_include = 0
+      first_include = None
       for section_list in include_state.include_list:
         for f in section_list:
           if headername in f[0] or f[0] in headername:

--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -57,6 +57,7 @@ _USAGE = """
 Syntax: cpplint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
                    [--counting=total|toplevel|detailed] [--root=subdir]
                    [--linelength=digits]
+                   [--headers=ext1,ext2]
         <file> [file] ...
 
   The style guidelines this tries to follow are those in
@@ -133,6 +134,13 @@ Syntax: cpplint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
 
       Examples:
         --extensions=hpp,cpp
+
+    headers=extension,extension,...
+      The allowed header extensions that cpplint will consider to be header files
+      (by default, only .h files will be assumed to be headers)
+
+      Examples:
+        --headers=h,hpp
 
     cpplint.py supports per-directory configurations specified in CPPLINT.cfg
     files. CPPLINT.cfg file can contain a number of key=value pairs.
@@ -503,7 +511,7 @@ _valid_extensions = set(['cc', 'h', 'cpp', 'cu', 'cuh'])
 
 # Files with any of these extensions are considered to be
 # header files (and will undergo different style checks).
-# This set can be extended by using the --header-extensions
+# This set can be extended by using the --headers
 # option (also supported in CPPLINT.cfg)
 _header_extensions = set(['h'])
 
@@ -6255,7 +6263,8 @@ def ParseArguments(args):
                                                  'filter=',
                                                  'root=',
                                                  'linelength=',
-                                                 'extensions='])
+                                                 'extensions=',
+                                                 'headers='])
   except getopt.GetoptError:
     PrintUsage('Invalid arguments.')
 
@@ -6294,6 +6303,12 @@ def ParseArguments(args):
       global _valid_extensions
       try:
           _valid_extensions = set(val.split(','))
+      except ValueError:
+          PrintUsage('Extensions must be comma seperated list.')
+    elif opt == '--headers':
+      global _header_extensions
+      try:
+          _header_extensions = set(val.split(','))
       except ValueError:
           PrintUsage('Extensions must be comma seperated list.')
 


### PR DESCRIPTION
Currently, `styleguide` only supports `.h` header files; this patch enables a more flexible approach, where any of a set of extensions (initialized, by default to be only `.h`, so no change from current behavior) will be treated as header files.

This is, for example, an issue for [Apache Mesos](http://mesos.apache.org) where we have "hacked" `cpplint.py` to include `.hpp` too.

This approach is cleaner and extensible.
Once (if?) you guys accept my other patch for `extensions` I will add support for `header_extensions` to `CCPLINT.cfg` too (if I do it here, it'll cause "merge confusion").

NOTE - the patch is not entirely PEP8 compliant: I tried instead to be consistent with existing code.
