### PR TITLE
Customize indent for access keywords.

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -497,6 +497,12 @@ _root = None
 # This is set by --linelength flag.
 _line_length = 80
 
+# The allowed indent for access keywords.
+# Set by default to +1, it can be changed with the
+# --access_keywords_indent (and correspondingly, in the CPPLINT.cfg
+# file too).
+_access_keyword_indent = 1
+
 # The allowed extensions for file names
 # This is set by --extensions flag.
 _valid_extensions = set(['cc', 'h', 'cpp', 'cu', 'cuh'])
@@ -1666,7 +1672,7 @@ def GetHeaderGuardCPPVariable(filename):
   filename = re.sub(r'/\.flymake/([^/]*)$', r'/\1', filename)
   # Replace 'c++' with 'cpp'.
   filename = filename.replace('C++', 'cpp').replace('c++', 'cpp')
-  
+
   fileinfo = FileInfo(filename)
   file_path_from_root = fileinfo.RepositoryName()
   if _root:
@@ -2199,7 +2205,8 @@ class _PreprocessorInfo(object):
 class NestingState(object):
   """Holds states related to parsing braces."""
 
-  def __init__(self):
+  def __init__(self, access_keyword_indent=1):
+    self.access_keyword_indent = access_keyword_indent
     # Stack for tracking all braces.  An object is pushed whenever we
     # see a "{", and popped when we see a "}".  Only 3 types of
     # objects are possible:
@@ -2484,8 +2491,8 @@ class NestingState(object):
         # Check that access keywords are indented +1 space.  Skip this
         # check if the keywords are not preceded by whitespaces.
         indent = access_match.group(1)
-        if (len(indent) != classinfo.class_indent + 1 and
-            Match(r'^\s*$', indent)):
+        if (len(indent) != classinfo.class_indent + self.access_keyword_indent and
+                (self.access_keyword_indent == 0 or Match(r'^\s*$', indent))):
           if classinfo.is_struct:
             parent = 'struct ' + classinfo.name
           else:
@@ -4794,7 +4801,7 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
 
   # Make Windows paths like Unix.
   fullname = os.path.abspath(filename).replace('\\', '/')
-  
+
   # Perform other checks now that we are sure that this is not an include line
   CheckCasts(filename, clean_lines, linenum, error)
   CheckGlobalStatic(filename, clean_lines, linenum, error)
@@ -6014,7 +6021,7 @@ def ProcessFileData(filename, file_extension, lines, error,
 
   include_state = _IncludeState()
   function_state = _FunctionState()
-  nesting_state = NestingState()
+  nesting_state = NestingState(access_keyword_indent=_access_keyword_indent)
 
   ResetNolintSuppressions()
 
@@ -6034,7 +6041,7 @@ def ProcessFileData(filename, file_extension, lines, error,
   nesting_state.CheckCompletedBlocks(filename, error)
 
   CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error)
-  
+
   # Check that the .cc file has included its header if it exists.
   if file_extension == 'cc':
     CheckHeaderFileIncluded(filename, include_state, error)
@@ -6103,6 +6110,12 @@ def ProcessConfigOverrides(filename):
                 _line_length = int(val)
             except ValueError:
                 sys.stderr.write('Line length must be numeric.')
+          elif name == 'access_keywords_indent':
+              global _access_keyword_indent
+              try:
+                  _access_keyword_indent = int(val)
+              except ValueError:
+                  sys.stderr.write('Access keyword indent must be numeric.')
           else:
             sys.stderr.write(
                 'Invalid configuration option (%s) in file %s\n' %
@@ -6289,6 +6302,12 @@ def ParseArguments(args):
           _valid_extensions = set(val.split(','))
       except ValueError:
           PrintUsage('Extensions must be comma seperated list.')
+    elif opt == '--access_keywords_indent':
+        global _access_keyword_indent
+        try:
+            _access_keyword_indent = int(val)
+        except ValueError:
+            PrintUsage('Access keywords indent values should be an integer value only.')
 
   if not filenames:
     PrintUsage('No files were specified.')


### PR DESCRIPTION
Adds the ability to customize the indent for access keywords (private/public/protected)
This can be done using either the --access_keywords_indent line option,
or in the CPPLINT.cfg file (using the same option).
