### PR TITLE
Python3000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -52,6 +52,21 @@ import string
 import sys
 import unicodedata
 
+Py3k = (sys.version_info[0] == 3)
+"""A boolean to check if we are running Python3000"""
+
+try:
+    xrange(0,1)
+except NameError:
+    xrange = range
+try:
+    unicode
+except NameError:
+    basestring = unicode = str
+try:
+    long
+except NameError:
+    long = int
 
 _USAGE = """
 Syntax: cpplint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
@@ -840,7 +855,11 @@ class _CppLintState(object):
 
   def PrintErrorCounts(self):
     """Print a summary of errors by category, and the total."""
-    for category, count in self.errors_by_category.iteritems():
+    try:
+        items = self.errors_by_category.iteritems()
+    except AttributeError:
+        items = self.errors_by_category.items()
+    for category, count in items:
       sys.stderr.write('Category \'%s\' errors found: %d\n' %
                        (category, count))
     sys.stderr.write('Total errors found: %d\n' % self.error_count)
@@ -1815,7 +1834,7 @@ def CheckForBadCharacters(filename, lines, error):
     error: The function to call with any errors found.
   """
   for linenum, line in enumerate(lines):
-    if u'\ufffd' in line:
+    if unicode(b'\xef\xbf\xbd', 'utf-8') in line:
       error(filename, linenum, 'readability/utf8', 5,
             'Line contains invalid UTF-8 (or Unicode replacement character).')
     if '\0' in line:
@@ -4701,7 +4720,10 @@ def _GetTextInside(text, start_pattern):
 
   # Give opening punctuations to get the matching close-punctuations.
   matching_punctuation = {'(': ')', '{': '}', '[': ']'}
-  closing_punctuation = set(matching_punctuation.itervalues())
+  try:
+    closing_punctuation = set(matching_punctuation.values())
+  except AttributeError:
+    closing_punctuation = set(matching_punctuation.itervalues())
 
   # Find the position to start extracting text.
   match = re.search(start_pattern, text, re.M)
@@ -5671,7 +5693,7 @@ def CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error,
 
   # include_dict is modified during iteration, so we iterate over a copy of
   # the keys.
-  header_keys = include_dict.keys()
+  header_keys = list(include_dict.keys())
   for header in header_keys:
     (same_module, common_path) = FilesBelongToSameModule(abs_filename, header)
     fullpath = common_path + header
@@ -6306,10 +6328,11 @@ def main():
 
   # Change stderr to write with replacement characters so we don't die
   # if we try to print something containing non-ASCII characters.
-  sys.stderr = codecs.StreamReaderWriter(sys.stderr,
-                                         codecs.getreader('utf8'),
-                                         codecs.getwriter('utf8'),
-                                         'replace')
+  if not Py3k:
+      sys.stderr = codecs.StreamReaderWriter(sys.stderr,
+                                             codecs.getreader('utf8'),
+                                             codecs.getwriter('utf8'),
+                                             'replace')
 
   _cpplint_state.ResetErrorCounts()
   for filename in filenames:
@@ -6321,3 +6344,4 @@ def main():
 
 if __name__ == '__main__':
   main()
+


### PR DESCRIPTION
Adds support for Python 3 by shimming changes in functionality between Python 2 and 3.

It also stops the compiled python files showing up in the `git status` list. This can be tested with:

```
[cpplint|python3000|✔] python2 cpplint/cpplint_unittest.py 
...........................................................................................................................................................................
----------------------------------------------------------------------
Ran 171 tests in 0.571s

OK
[cpplint|python3000|✔] python3 cpplint/cpplint_unittest.py 
cpplint/cpplint_unittest.py:4713: DeprecationWarning: Please use assertEqual instead.
  self.PerformFunctionLengthsCheck(code))
.cpplint/cpplint_unittest.py:83: DeprecationWarning: Please use assertTrue instead.
  ' which is not in _ERROR_CATEGORIES' % (message, category))
..........................................................................................................................................................................
----------------------------------------------------------------------
Ran 171 tests in 0.641s

OK
[cpplint|python3000|✔] python2 --version
Python 2.7.10
[cpplint|python3000|✔] python3 --version
Python 3.4.3
```
