### PR TITLE
Ignore Doxygen Long Lines

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -4445,9 +4445,13 @@ def CheckStyle(filename, clean_lines, linenum, file_extension, nesting_state,
   #
   # The "$Id:...$" comment may also get very long without it being the
   # developers fault.
+  #
+  # Doxygen documentation copying can get pretty long when using an overloaded
+  # function declaration
   if (not line.startswith('#include') and not is_header_guard and
       not Match(r'^\s*//.*http(s?)://\S*$', line) and
-      not Match(r'^// \$Id:.*#[0-9]+ \$$', line)):
+      not Match(r'^// \$Id:.*#[0-9]+ \$$', line) and
+      not Match(r'^\s*/// [@\\](copydoc|copydetails|copybrief) .*$', line)):
     line_width = GetLineWidth(line)
     extended_length = int((_line_length * 1.25))
     if line_width > extended_length:

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -405,6 +405,15 @@ class CpplintTest(CpplintTestBase):
         'static const char kL' + ('o' * 50) + 'ngIdentifier[] = R"()";\n',
         'Lines should be <= 80 characters long'
         '  [whitespace/line_length] [2]')
+    self.TestLint(
+        '  /// @copydoc ' + ('o' * (cpplint._line_length * 2)),
+        '')
+    self.TestLint(
+        '  /// @copydetails ' + ('o' * (cpplint._line_length * 2)),
+        '')
+    self.TestLint(
+        '  /// @copybrief ' + ('o' * (cpplint._line_length * 2)),
+        '')
 
   # Test error suppression annotations.
   def testErrorSuppression(self):


### PR DESCRIPTION
There is a special command in Doxygen that allow documentation to be copied from another function but the full declaration must be put on one line. This result in an error in `cpplint` but to solve the error `// NOLINT` must be put on the line, which means that Doxygen fails to pick up the overload. This ignores any single line Doxygen documentation copy commands:

```
/// @copydoc SomeOverloadFunction(const int lots, const int of, const int lengthy, const int parameters)
```
