### PR TITLE
Remove BOM

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -6160,6 +6160,12 @@ def ProcessFile(filename, vlevel, extra_check_functions=[]):
     else:
       lines = codecs.open(filename, 'r', 'utf8', 'replace').read().split('\n')
 
+    # Remove BOM
+    if lines and lines[0]:
+      ord0 = ord(lines[0][0])
+      if ord0 == 0xfeff:
+        lines[0] = lines[0][1:]
+
     # Remove trailing '\r'.
     # The -1 accounts for the extra trailing blank line we get from split()
     for linenum in range(len(lines) - 1):


### PR DESCRIPTION
Thank you for maintain.

Sometime, utf-8 text file specify byte order mark(BOM) at the begginings of file.
http://en.wikipedia.org/wiki/Unicode

But cpplint.py is not support BOM.

For example, 'cplint.py japanese_utf8.cpp' raises error in first line.

```
japanese_utf8.cpp:1:  At least two spaces is best between code and comments  [whitespace/comments] [2]
```

This pull request fixs this problem.
