### PR TITLE
google_python_style.vim: indent once inside parens

### DIFF
--- a/google_python_style.vim
+++ b/google_python_style.vim
@@ -32,5 +32,5 @@ function GetGooglePythonIndent(lnum)
 
 endfunction
 
-let pyindent_nested_paren="&sw*2"
-let pyindent_open_paren="&sw*2"
+let pyindent_nested_paren="&sw"
+let pyindent_open_paren="&sw"


### PR DESCRIPTION
This change modifies the hanging indent behaviour of the Vim Python indenter to match [Google's **external** style guide](http://google.github.io/styleguide/pyguide.html#Indentation).

> Indent your code blocks with 4 spaces.
> 
> In cases of implied line continuation, you should align wrapped elements [...] using a hanging indent of 4 spaces

Compare the quoted section with your internal guide.

The doubling is not necessary with a base indent of four spaces.
