### PR TITLE
Fix running cpplint.py from the Windows command line

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
On Windows, if the Python interpreter in your path is Python 3, executing cpplint.py from the command line will fail but nothing will be output to the console.

This little fix allows py.exe (the Python Launcher for Windows) to correctly choose the right interpreter.
