### PR TITLE
Fix static import ordering.

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -16,6 +16,8 @@
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
+      <package name="" withSubpackages="true" static="true" />
+      <emptyLine />
       <package name="com.google" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="android" withSubpackages="true" static="false" />
@@ -247,8 +249,6 @@
       <package name="javax" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="true" />
     </value>
   </option>
   <option name="RIGHT_MARGIN" value="100" />


### PR DESCRIPTION
The javaguide says that static imports have to be the first one.
http://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing
