### PR TITLE
Fixed cppguide.xml redirect.

### DIFF
--- a/cppguide.xml
+++ b/cppguide.xml
@@ -1,18 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf8">
-  <meta http-equiv="content-type" content="text/html;charset=utf-8">
-  <meta http-equiv="refresh" content="1; url=cppguide.html">
-  <title>Redirecting</title>
-</head>
-<!-- The BODY onLoad redirect is the best: it preserves #fragments and
-     ?queries.  But it requires javascript.  If that fails, the
-     meta-refresh kicks in; it works more generally, but loses fragments
-     and queries, takes a second, and pollutes the browser history.
-     If they both fail, we let the user manually click on the new link.
--->
- <body onload="location.replace(location.href.replace('.xml', '.html'))">
-  Redirecting you to <a href="cppguide.html">cppguide.html</a>.
-</body>
-</html>
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="styleguide.xsl"?>
+<REDIRECT title="Redirecting" url="cppguide.html">
+</REDIRECT>

--- a/styleguide.xsl
+++ b/styleguide.xsl
@@ -920,5 +920,40 @@ xmlns:fn="http://www.w3.org/2005/xpath-functions">
       </xsl:call-template>
     </xsl:if>
   </xsl:template>
+
+  <!-- Given a url, redirect to it.
+       The BODY onLoad redirect is the best: it preserves #fragments and
+       ?queries.  But it requires javascript.  If that fails, the
+       meta-refresh kicks in; it works more generally, but loses fragments
+       and queries, takes a second, and pollutes the browser history.
+       If they both fail, we let the user manually click on the new link.
+  -->
+  <xsl:template match="REDIRECT">
+      <HTML>
+          <HEAD>
+              <TITLE><xsl:value-of select="@title"/></TITLE>
+              <META http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+              <META http-equiv="refresh">
+                <xsl:attribute name="content">
+                  <xsl:value-of select="'1; url='"/>
+                  <xsl:value-of select="@url"/>
+                </xsl:attribute>
+              </META>
+              <LINK HREF="http://www.google.com/favicon.ico" type="image/x-icon"
+                    rel="shortcut icon"/>
+              <LINK HREF="styleguide.css"
+                    type="text/css" rel="stylesheet"/>
+          </HEAD>
+          <BODY>
+            <xsl:attribute name="onload"><xsl:value-of select="'location.replace(location.href.replace(`.xml`, `.html`))'"/></xsl:attribute>
+            Redirecting you to
+            <A>
+              <xsl:attribute name="href"><xsl:value-of select="@url"/></xsl:attribute>
+              <xsl:value-of select="@url"/>
+            </A>.
+            <xsl:apply-templates/>
+          </BODY>
+      </HTML>
+  </xsl:template>
 </xsl:stylesheet>
 


### PR DESCRIPTION
The [C++ formatting rules url](https://google.github.io/styleguide/cppguide.xml#Formatting) linked [here](https://google.github.io/styleguide/javascriptguide.xml#Code_formatting) throws the following error:

![screen shot 2015-09-23 at 10 00 13 pm](https://cloud.githubusercontent.com/assets/877919/10055627/f4b8acb8-623f-11e5-99dc-3d4975e9d3a7.png)

This PR fixes the error by adding a redirect template that receives a url to redirect to and a
page title. It also keeps the same best practice of using a BODY onLoad redirect, with a meta-refresh fallback.
