### PR TITLE
Single line lambdas

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -4459,6 +4459,9 @@ def CheckStyle(filename, clean_lines, linenum, file_extension, nesting_state,
             'Lines should be <= %i characters long' % _line_length)
 
   if (cleansed_line.count(';') > 1 and
+      # allow simple single line lambdas
+      not Match(r'^[^{};]*\[[^\[\]]*\][^{}]*\{[^{}\n\r]*\}',
+                line) and
       # for loops are allowed two ;'s (and may run over two lines).
       cleansed_line.find('for') == -1 and
       (GetPreviousNonBlankLine(clean_lines, linenum)[0].find('for') == -1 or

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -3182,6 +3182,54 @@ class CpplintTest(CpplintTestBase):
                             error_collector)
     cpplint._cpplint_state.verbose_level = old_verbose_level
 
+  def testLambdasOnSameLine(self):
+    error_collector = ErrorCollector(self.assert_)
+    old_verbose_level = cpplint._cpplint_state.verbose_level
+    cpplint._cpplint_state.verbose_level = 0
+    cpplint.ProcessFileData('foo.cc', 'cc',
+                            ['const auto lambda = '
+                              '[](const int i) { return i; };'],
+                            error_collector)
+    cpplint._cpplint_state.verbose_level = old_verbose_level
+    self.assertEquals(0, error_collector.Results().count(
+        'More than one command on the same line  [whitespace/newline] [0]'))
+
+    error_collector = ErrorCollector(self.assert_)
+    old_verbose_level = cpplint._cpplint_state.verbose_level
+    cpplint._cpplint_state.verbose_level = 0
+    cpplint.ProcessFileData('foo.cc', 'cc',
+                            ['const auto result = std::any_of(vector.begin(), '
+                              'vector.end(), '
+                              '[](const int i) { return i > 0; });'],
+                            error_collector)
+    cpplint._cpplint_state.verbose_level = old_verbose_level
+    self.assertEquals(0, error_collector.Results().count(
+        'More than one command on the same line  [whitespace/newline] [0]'))
+
+    error_collector = ErrorCollector(self.assert_)
+    old_verbose_level = cpplint._cpplint_state.verbose_level
+    cpplint._cpplint_state.verbose_level = 0
+    cpplint.ProcessFileData('foo.cc', 'cc',
+                            ['return mutex::Lock<void>([this]() { '
+                              'this->ReadLock(); }, [this]() { '
+                              'this->ReadUnlock(); });'],
+                            error_collector)
+    cpplint._cpplint_state.verbose_level = old_verbose_level
+    self.assertEquals(0, error_collector.Results().count(
+        'More than one command on the same line  [whitespace/newline] [0]'))
+
+    error_collector = ErrorCollector(self.assert_)
+    old_verbose_level = cpplint._cpplint_state.verbose_level
+    cpplint._cpplint_state.verbose_level = 0
+    cpplint.ProcessFileData('foo.cc', 'cc',
+                            ['return mutex::Lock<void>([this]() { '
+                              'this->ReadLock(); }, [this]() { '
+                              'this->ReadUnlock(); }, object);'],
+                            error_collector)
+    cpplint._cpplint_state.verbose_level = old_verbose_level
+    self.assertEquals(0, error_collector.Results().count(
+        'More than one command on the same line  [whitespace/newline] [0]'))
+
   def testEndOfNamespaceComments(self):
     error_collector = ErrorCollector(self.assert_)
     cpplint.ProcessFileData('foo.cc', 'cc',


### PR DESCRIPTION
Allows the following code to be allowed:

```
const auto lambda = [](const int i) { return i; };
const auto result = std::any_of(vector.begin(), vector.end(), [](const int i) { return i > 0; });
```

Which is useful because `clang-format` collapses simple lambdas. 
