### PR TITLE
Explicit variadic constructors

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -2694,6 +2694,7 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
       constructor_args[i] = constructor_arg
       i += 1
 
+    variadic_args = [arg for arg in constructor_args if '&&...' in arg]
     defaulted_args = [arg for arg in constructor_args if '=' in arg]
     noarg_constructor = (not constructor_args or  # empty arg list
                          # 'void' arg specifier
@@ -2704,7 +2705,10 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
                           # all but at most one arg defaulted
                           (len(constructor_args) >= 1 and
                            not noarg_constructor and
-                           len(defaulted_args) >= len(constructor_args) - 1))
+                           len(defaulted_args) >= len(constructor_args) - 1) or
+                          # variadic arguments with zero or one argument
+                          (len(constructor_args) <= 2 and
+                           len(variadic_args) >= 1))
     initializer_list_constructor = bool(
         onearg_constructor and
         Search(r'\bstd\s*::\s*initializer_list\b', constructor_args[0]))
@@ -2717,7 +2721,7 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
         onearg_constructor and
         not initializer_list_constructor and
         not copy_constructor):
-      if defaulted_args:
+      if defaulted_args or variadic_args:
         error(filename, linenum, 'runtime/explicit', 5,
               'Constructors callable with one argument '
               'should be marked explicit.')

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -1338,6 +1338,47 @@ class CpplintTest(CpplintTestBase):
             Foo(std::initializer_list<T> &arg) {}
           };""",
           '')
+      # Special case for variadic arguments
+      error_collector = ErrorCollector(self.assert_)
+      cpplint.ProcessFileData('foo.cc', 'cc',
+          ['class Foo {',
+          '  template<typename... Args>',
+          '  explicit Foo(const int arg, Args&&... args) {}',
+          '};'],
+          error_collector)
+      self.assertEquals(0, error_collector.ResultList().count(
+        'Constructors that require multiple arguments should not be marked '
+        'explicit.  [runtime/explicit] [0]'))
+      error_collector = ErrorCollector(self.assert_)
+      cpplint.ProcessFileData('foo.cc', 'cc',
+          ['class Foo {',
+          '  template<typename... Args>',
+          '  explicit Foo(Args&&... args) {}',
+          '};'],
+          error_collector)
+      self.assertEquals(0, error_collector.ResultList().count(
+        'Constructors that require multiple arguments should not be marked '
+        'explicit.  [runtime/explicit] [0]'))
+      error_collector = ErrorCollector(self.assert_)
+      cpplint.ProcessFileData('foo.cc', 'cc',
+          ['class Foo {',
+          '  template<typename... Args>',
+          '  Foo(const int arg, Args&&... args) {}',
+          '};'],
+          error_collector)
+      self.assertEquals(1, error_collector.ResultList().count(
+        'Constructors callable with one argument should be marked explicit.'
+        '  [runtime/explicit] [5]'))
+      error_collector = ErrorCollector(self.assert_)
+      cpplint.ProcessFileData('foo.cc', 'cc',
+          ['class Foo {',
+          '  template<typename... Args>',
+          '  Foo(Args&&... args) {}',
+          '};'],
+          error_collector)
+      self.assertEquals(1, error_collector.ResultList().count(
+        'Constructors callable with one argument should be marked explicit.'
+        '  [runtime/explicit] [5]'))
       # Anything goes inside an assembly block
       error_collector = ErrorCollector(self.assert_)
       cpplint.ProcessFileData('foo.cc', 'cc',


### PR DESCRIPTION
Makes sure that variadic constructors are marked explicit. We want to avoid this:

```
#include <iostream>
#include <vector>

struct A {
    template<typename... Args>
    explicit A(const int one, Args&&... args)
        : vector_({one, std::forward<Args>(args)...}) {}
    std::vector<int> vector_;
};

std::ostream& operator<<(std::ostream& stream, const A& a) {
    char comma = '[';
    for (auto&& element : a.vector_) {
        stream << comma << element;
        comma = ',';
    }
    if (a.vector_.empty()) stream.put(comma);
    return stream.put(']');
}

static void print(const A& a) {
    std::cout << a << std::endl;
}

int main()
{
    A a(1);
    print(a);
//    print(2); <-- Don't want implicit conversion!!
    return 0;
}
```
