### PR TITLE
Change cppguide.xml to proper XML serialized HTML

### DIFF
--- a/cppguide.xml
+++ b/cppguide.xml
@@ -1,9 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta charset="utf8">
-  <meta http-equiv="content-type" content="text/html;charset=utf-8">
-  <meta http-equiv="refresh" content="1; url=cppguide.html">
+  <meta http-equiv="refresh" content="1; url=cppguide.html"/>
   <title>Redirecting</title>
 </head>
 <!-- The BODY onLoad redirect is the best: it preserves #fragments and


### PR DESCRIPTION
cppguide.xml does not contain valid XML. xmllint can not parse it and chrome can not display it.

```
# xmllint cppguide.xml
cppguide.xml:8: parser error : Opening and ending tag mismatch: meta line 6 and head
</head>
       ^
cppguide.xml:18: parser error : Opening and ending tag mismatch: meta line 5 and html
</html>
       ^
cppguide.xml:19: parser error : Premature end of data in tag meta line 4

^
cppguide.xml:19: parser error : Premature end of data in tag head line 3

^
cppguide.xml:19: parser error : Premature end of data in tag html line 2

^
```

`chrome http://google.github.io/styleguide/cppguide.xml`

```
XML Parsing Error: mismatched tag. Expected: </meta>.
Location: http://google.github.io/styleguide/cppguide.xml
Line Number 8, Column 3:

</head>
--^
```

Validated the changes with https://validator.w3.org/
