### PR TITLE
Fix links in C++ guide to point to GitHub

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -615,7 +615,7 @@ bool UpdateInternals(Frobber* f, int newval) {
 
   <p>Namespaces wrap the entire source file after
   includes,  
-  <a href="http://google-gflags.googlecode.com/">
+  <a href="http://gflags.github.io/gflags/">
   gflags</a> definitions/declarations
   and forward declarations of classes from other namespaces.</p>
 
@@ -2239,7 +2239,7 @@ NOLINT</code> at the end of the line or
 how to run <code>cpplint.py</code> from their project
 tools. If the project you are contributing to does not,
 you can download
-<a href="http://google-styleguide.googlecode.com/svn/trunk/cpplint/cpplint.py">
+<a href="https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py">
 <code>cpplint.py</code></a> separately.</p>
 
 </div> 
@@ -4925,7 +4925,7 @@ everyone's code easily.</p>
 
 <p>To help you format code correctly, we've
 created a
-<a href="http://google-styleguide.googlecode.com/svn/trunk/google-c-style.el">
+<a href="https://raw.githubusercontent.com/google/styleguide/gh-pages/google-c-style.el">
 settings file for emacs</a>.</p>
 
 <h3 id="Line_Length">Line Length</h3>


### PR DESCRIPTION
The links were pointing to googlecode.com. Two of them resulted in "404
Not Found", one resulted in the message "the project is moved".
