### PR TITLE
Using namespace literals

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -4860,7 +4860,7 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
           'Did you mean "memset(%s, 0, %s)"?'
           % (match.group(1), match.group(2)))
 
-  if Search(r'\busing namespace\b', line):
+  if Search(r'\busing namespace\b', line) and not Search(r'\bliterals\b', line):
     error(filename, linenum, 'build/namespaces', 5,
           'Do not use namespace using-directives.  '
           'Use using-declarations instead.')

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -2908,6 +2908,10 @@ class CpplintTest(CpplintTestBase):
     DoTest(self, ['', '', '', 'using namespace foo;'])
     DoTest(self, ['// hello', 'using namespace foo;'])
 
+  def testUsingLiteralsNamespaces(self):
+    self.TestLint('using namespace std::literals;', '')
+    self.TestLint('using namespace std::literals::chrono_literals;', '')
+
   def testNewlineAtEOF(self):
     def DoTest(self, data, is_missing_eof):
       error_collector = ErrorCollector(self.assert_)


### PR DESCRIPTION
In C++14 new user defined literals are, by convention, contained in a namespace `literals`:

```
#include <iostream>
#include <chrono>
int main()
{
    using namespace std::chrono_literals;
    auto day = 24h;
    auto halfhour = 0.5h;
}
```

We should allow these types of `using` declarations.
