### PR TITLE
Modernize IntelliJ style file

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <code_scheme name="GoogleStyle">
-  <option name="JAVA_INDENT_OPTIONS">
-    <value>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="8" />
-      <option name="USE_TAB_CHARACTER" value="false" />
-      <option name="SMART_TABS" value="false" />
-      <option name="LABEL_INDENT_SIZE" value="0" />
-      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-      <option name="USE_RELATIVE_INDENTS" value="false" />
-    </value>
-  </option>
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="IMPORT_LAYOUT_TABLE">
@@ -256,127 +244,7 @@
   <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
   <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
   <option name="JD_KEEP_EMPTY_RETURN" value="false" />
-  <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-  <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-  <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-  <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-  <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-  <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
-  <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-  <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
-  <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-  <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
-  <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
-  <option name="CALL_PARAMETERS_WRAP" value="1" />
-  <option name="METHOD_PARAMETERS_WRAP" value="1" />
-  <option name="EXTENDS_LIST_WRAP" value="1" />
-  <option name="THROWS_LIST_WRAP" value="1" />
-  <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-  <option name="THROWS_KEYWORD_WRAP" value="1" />
-  <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-  <option name="BINARY_OPERATION_WRAP" value="1" />
-  <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-  <option name="TERNARY_OPERATION_WRAP" value="1" />
-  <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-  <option name="FOR_STATEMENT_WRAP" value="1" />
-  <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-  <option name="ASSIGNMENT_WRAP" value="5" />
-  <option name="WRAP_COMMENTS" value="true" />
-  <option name="IF_BRACE_FORCE" value="3" />
-  <option name="DOWHILE_BRACE_FORCE" value="3" />
-  <option name="WHILE_BRACE_FORCE" value="3" />
-  <option name="FOR_BRACE_FORCE" value="3" />
-  <ADDITIONAL_INDENT_OPTIONS fileType="css">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="haml">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="java">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="4" />
-    <option name="TAB_SIZE" value="8" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="js">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="4" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="jsp">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="php">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="sass">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="xml">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="yml">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <codeStyleSettings language="ECMA Script Level 4">
+  <codeStyleSettings language="JAVA">
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
@@ -407,7 +275,40 @@
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="8" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="CSS">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="HAML">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JavaScript">
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
@@ -441,6 +342,28 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="JSP">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="PHP">
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
@@ -471,6 +394,52 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="SASS">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="XML">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="yaml">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
   </codeStyleSettings>
 </code_scheme>
 


### PR DESCRIPTION
This removes tags from the style file that are no longer being read by
IntelliJ, and adds them back in the new format.  Without this change,
it's not even possible to use the style file in IntelliJ 15 or later,
since most of the old tags are not being read by the IDE.
