### PR TITLE
google-c-style.el: Set default 80 for Emacs fill-paragraph

### DIFF
--- a/google-c-style.el
+++ b/google-c-style.el
@@ -97,6 +97,7 @@ Suitable for inclusion in `c-offsets-alist'."
         c-semi&comma-no-newlines-before-nonblanks))
     (c-indent-comments-syntactically-p . t)
     (comment-column . 40)
+    (fill-column . 80)
     (c-indent-comment-alist . ((other . (space . 2))))
     (c-cleanup-list . (brace-else-brace
                        brace-elseif-brace


### PR DESCRIPTION
In Emacs, `M-x fill-paragraph` is a useful command to format comments in C++ code, the Emacs default value is 70, but the recommended style for C++ is 80. Let's use the default setting in Emacs.
