### PR TITLE
CppLint: Make output appear in the Visual Studio Error List

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1114,7 +1114,7 @@ def Error(filename, linenum, category, confidence, message):
   if _ShouldPrintError(category, confidence, linenum):
     _cpplint_state.IncrementErrorCount(category)
     if _cpplint_state.output_format == 'vs7':
-      sys.stderr.write('%s(%s):  %s  [%s] [%d]\n' % (
+      sys.stderr.write('%s(%s): warning: %s  [%s] [%d]\n' % (
           filename, linenum, message, category, confidence))
     elif _cpplint_state.output_format == 'eclipse':
       sys.stderr.write('%s:%s: warning: %s  [%s] [%d]\n' % (


### PR DESCRIPTION
Visual Studio 2003 - 2015 keep following output format:

```
{filename (line# [, column#]) | toolname} : [any text] {error | warning} code####: localizable string [any text]
```

[source](https://msdn.microsoft.com/en-us/library/yxkt8b26%28v=vs.140%29.aspx)

In CppLint the `{error | warning}` part is missing causing the output to only appear in the 'Output' screen and not in the 'Error List'. This makes the warnings more difficult to detect. This pull request simply adds 'warning:' to the output string.
