### PR TITLE
Sync Java IDE styles with internal configuration

### DIFF
--- a/eclipse-java-google-style.xml
+++ b/eclipse-java-google-style.xml
@@ -143,7 +143,7 @@
 <setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.comment_new_line_at_start_of_html_paragraph" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment_new_line_at_start_of_html_paragraph" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comment_prefix" value="do not insert"/>

--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -7,258 +7,11 @@
       <option name="TAB_SIZE" value="8" />
       <option name="USE_TAB_CHARACTER" value="false" />
       <option name="SMART_TABS" value="false" />
-      <option name="LABEL_INDENT_SIZE" value="0" />
-      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-      <option name="USE_RELATIVE_INDENTS" value="false" />
     </value>
   </option>
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-  <option name="IMPORT_LAYOUT_TABLE">
-    <value>
-      <package name="com.google" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="android" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="antenna" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="antlr" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ar" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="asposewobfuscated" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="asquare" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="atg" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="au" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="beaver" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="bibtex" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="bmsi" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="bsh" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ccl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="cern" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ChartDirector" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="checkers" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="com" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="COM" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="common" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="contribs" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="corejava" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="cryptix" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="cybervillains" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="dalvik" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="danbikel" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="de" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="EDU" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="eg" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="eu" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="examples" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="fat" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="fit" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="fitlibrary" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="fmpp" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="freemarker" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="gnu" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="groovy" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="groovyjarjarantlr" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="groovyjarjarasm" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="hak" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="hep" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ie" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="imageinfo" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="info" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="it" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jal" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="Jama" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="japa" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="japacheckers" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jas" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jasmin" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javancss" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javanet" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javassist" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javazoom" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="java_cup" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jcifs" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jetty" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="JFlex" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jj2000" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jline" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jp" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="JSci" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jsr166y" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="junit" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jxl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jxxload_help" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="kawa" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="kea" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="libcore" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="libsvm" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="lti" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="memetic" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="mt" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="mx4j" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="net" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="netscape" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="nl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="nu" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="oauth" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ognl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="opennlp" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="oracle" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="org" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="penn2dg" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="pennconverter" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="pl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="prefuse" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="proguard" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="repackage" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="scm" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="se" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="serp" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="simple" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="soot" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="sqlj" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="src" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ssa" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="sun" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="sunlabs" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="tcl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="testdata" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="testshell" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="testsuite" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="twitter4j" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="uk" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ViolinStrings" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="weka" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="wet" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="winstone" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="woolfel" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="wowza" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="java" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javax" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="true" />
-    </value>
-  </option>
-  <option name="RIGHT_MARGIN" value="100" />
-  <option name="JD_P_AT_EMPTY_LINES" value="false" />
-  <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
-  <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
-  <option name="JD_KEEP_EMPTY_RETURN" value="false" />
   <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-  <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-  <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
+  <option name="ALIGN_MULTILINE_PARAMETERS" value="true" />
+  <option name="ALIGN_MULTILINE_FOR" value="true" />
   <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
   <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
   <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
@@ -267,6 +20,132 @@
   <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
   <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
   <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+  <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+  <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="IMPORT_LAYOUT_TABLE">
+    <value>
+      <package name="com.google" withSubpackages="true" />
+      <emptyLine /> <package name="android" withSubpackages="true" />
+      <emptyLine /> <package name="antenna" withSubpackages="true" />
+      <emptyLine /> <package name="antlr" withSubpackages="true" />
+      <emptyLine /> <package name="ar" withSubpackages="true" />
+      <emptyLine /> <package name="asposewobfuscated" withSubpackages="true" />
+      <emptyLine /> <package name="asquare" withSubpackages="true" />
+      <emptyLine /> <package name="atg" withSubpackages="true" />
+      <emptyLine /> <package name="au" withSubpackages="true" />
+      <emptyLine /> <package name="beaver" withSubpackages="true" />
+      <emptyLine /> <package name="bibtex" withSubpackages="true" />
+      <emptyLine /> <package name="bmsi" withSubpackages="true" />
+      <emptyLine /> <package name="bsh" withSubpackages="true" />
+      <emptyLine /> <package name="ccl" withSubpackages="true" />
+      <emptyLine /> <package name="cern" withSubpackages="true" />
+      <emptyLine /> <package name="ChartDirector" withSubpackages="true" />
+      <emptyLine /> <package name="checkers" withSubpackages="true" />
+      <emptyLine /> <package name="com" withSubpackages="true" />
+      <emptyLine /> <package name="COM" withSubpackages="true" />
+      <emptyLine /> <package name="common" withSubpackages="true" />
+      <emptyLine /> <package name="contribs" withSubpackages="true" />
+      <emptyLine /> <package name="corejava" withSubpackages="true" />
+      <emptyLine /> <package name="cryptix" withSubpackages="true" />
+      <emptyLine /> <package name="cybervillains" withSubpackages="true" />
+      <emptyLine /> <package name="dalvik" withSubpackages="true" />
+      <emptyLine /> <package name="danbikel" withSubpackages="true" />
+      <emptyLine /> <package name="de" withSubpackages="true" />
+      <emptyLine /> <package name="EDU" withSubpackages="true" />
+      <emptyLine /> <package name="eg" withSubpackages="true" />
+      <emptyLine /> <package name="eu" withSubpackages="true" />
+      <emptyLine /> <package name="examples" withSubpackages="true" />
+      <emptyLine /> <package name="fat" withSubpackages="true" />
+      <emptyLine /> <package name="fit" withSubpackages="true" />
+      <emptyLine /> <package name="fitlibrary" withSubpackages="true" />
+      <emptyLine /> <package name="fmpp" withSubpackages="true" />
+      <emptyLine /> <package name="freemarker" withSubpackages="true" />
+      <emptyLine /> <package name="gnu" withSubpackages="true" />
+      <emptyLine /> <package name="groovy" withSubpackages="true" />
+      <emptyLine /> <package name="groovyjarjarantlr" withSubpackages="true" />
+      <emptyLine /> <package name="groovyjarjarasm" withSubpackages="true" />
+      <emptyLine /> <package name="hak" withSubpackages="true" />
+      <emptyLine /> <package name="hep" withSubpackages="true" />
+      <emptyLine /> <package name="ie" withSubpackages="true" />
+      <emptyLine /> <package name="imageinfo" withSubpackages="true" />
+      <emptyLine /> <package name="info" withSubpackages="true" />
+      <emptyLine /> <package name="it" withSubpackages="true" />
+      <emptyLine /> <package name="jal" withSubpackages="true" />
+      <emptyLine /> <package name="Jama" withSubpackages="true" />
+      <emptyLine /> <package name="japa" withSubpackages="true" />
+      <emptyLine /> <package name="japacheckers" withSubpackages="true" />
+      <emptyLine /> <package name="jas" withSubpackages="true" />
+      <emptyLine /> <package name="jasmin" withSubpackages="true" />
+      <emptyLine /> <package name="javancss" withSubpackages="true" />
+      <emptyLine /> <package name="javanet" withSubpackages="true" />
+      <emptyLine /> <package name="javassist" withSubpackages="true" />
+      <emptyLine /> <package name="javazoom" withSubpackages="true" />
+      <emptyLine /> <package name="java_cup" withSubpackages="true" />
+      <emptyLine /> <package name="jcifs" withSubpackages="true" />
+      <emptyLine /> <package name="jetty" withSubpackages="true" />
+      <emptyLine /> <package name="JFlex" withSubpackages="true" />
+      <emptyLine /> <package name="jj2000" withSubpackages="true" />
+      <emptyLine /> <package name="jline" withSubpackages="true" />
+      <emptyLine /> <package name="jp" withSubpackages="true" />
+      <emptyLine /> <package name="JSci" withSubpackages="true" />
+      <emptyLine /> <package name="jsr166y" withSubpackages="true" />
+      <emptyLine /> <package name="junit" withSubpackages="true" />
+      <emptyLine /> <package name="jxl" withSubpackages="true" />
+      <emptyLine /> <package name="jxxload_help" withSubpackages="true" />
+      <emptyLine /> <package name="kawa" withSubpackages="true" />
+      <emptyLine /> <package name="kea" withSubpackages="true" />
+      <emptyLine /> <package name="libcore" withSubpackages="true" />
+      <emptyLine /> <package name="libsvm" withSubpackages="true" />
+      <emptyLine /> <package name="lti" withSubpackages="true" />
+      <emptyLine /> <package name="memetic" withSubpackages="true" />
+      <emptyLine /> <package name="mt" withSubpackages="true" />
+      <emptyLine /> <package name="mx4j" withSubpackages="true" />
+      <emptyLine /> <package name="net" withSubpackages="true" />
+      <emptyLine /> <package name="netscape" withSubpackages="true" />
+      <emptyLine /> <package name="nl" withSubpackages="true" />
+      <emptyLine /> <package name="nu" withSubpackages="true" />
+      <emptyLine /> <package name="oauth" withSubpackages="true" />
+      <emptyLine /> <package name="ognl" withSubpackages="true" />
+      <emptyLine /> <package name="opennlp" withSubpackages="true" />
+      <emptyLine /> <package name="oracle" withSubpackages="true" />
+      <emptyLine /> <package name="org" withSubpackages="true" />
+      <emptyLine /> <package name="penn2dg" withSubpackages="true" />
+      <emptyLine /> <package name="pennconverter" withSubpackages="true" />
+      <emptyLine /> <package name="pl" withSubpackages="true" />
+      <emptyLine /> <package name="prefuse" withSubpackages="true" />
+      <emptyLine /> <package name="proguard" withSubpackages="true" />
+      <emptyLine /> <package name="repackage" withSubpackages="true" />
+      <emptyLine /> <package name="scm" withSubpackages="true" />
+      <emptyLine /> <package name="se" withSubpackages="true" />
+      <emptyLine /> <package name="serp" withSubpackages="true" />
+      <emptyLine /> <package name="simple" withSubpackages="true" />
+      <emptyLine /> <package name="soot" withSubpackages="true" />
+      <emptyLine /> <package name="sqlj" withSubpackages="true" />
+      <emptyLine /> <package name="src" withSubpackages="true" />
+      <emptyLine /> <package name="ssa" withSubpackages="true" />
+      <emptyLine /> <package name="sun" withSubpackages="true" />
+      <emptyLine /> <package name="sunlabs" withSubpackages="true" />
+      <emptyLine /> <package name="tcl" withSubpackages="true" />
+      <emptyLine /> <package name="testdata" withSubpackages="true" />
+      <emptyLine /> <package name="testshell" withSubpackages="true" />
+      <emptyLine /> <package name="testsuite" withSubpackages="true" />
+      <emptyLine /> <package name="twitter4j" withSubpackages="true" />
+      <emptyLine /> <package name="uk" withSubpackages="true" />
+      <emptyLine /> <package name="ViolinStrings" withSubpackages="true" />
+      <emptyLine /> <package name="weka" withSubpackages="true" />
+      <emptyLine /> <package name="wet" withSubpackages="true" />
+      <emptyLine /> <package name="winstone" withSubpackages="true" />
+      <emptyLine /> <package name="woolfel" withSubpackages="true" />
+      <emptyLine /> <package name="wowza" withSubpackages="true" />
+
+      <emptyLine /> <package name="java" withSubpackages="true" />
+      <emptyLine /> <package name="javax" withSubpackages="true" />
+      <emptyLine /> <package name="" withSubpackages="true" />
+    </value>
+  </option>
+  <option name="RIGHT_MARGIN" value="100" />
   <option name="CALL_PARAMETERS_WRAP" value="1" />
   <option name="METHOD_PARAMETERS_WRAP" value="1" />
   <option name="EXTENDS_LIST_WRAP" value="1" />
@@ -278,6 +157,7 @@
   <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
   <option name="TERNARY_OPERATION_WRAP" value="1" />
   <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+  <option name="ANNOTATIONS_LIST_WRAP" value="true" />
   <option name="FOR_STATEMENT_WRAP" value="1" />
   <option name="ARRAY_INITIALIZER_WRAP" value="1" />
   <option name="ASSIGNMENT_WRAP" value="5" />
@@ -286,191 +166,9 @@
   <option name="DOWHILE_BRACE_FORCE" value="3" />
   <option name="WHILE_BRACE_FORCE" value="3" />
   <option name="FOR_BRACE_FORCE" value="3" />
-  <ADDITIONAL_INDENT_OPTIONS fileType="css">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="haml">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="java">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="4" />
-    <option name="TAB_SIZE" value="8" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="js">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="4" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="jsp">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="php">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="sass">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="xml">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="yml">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <codeStyleSettings language="ECMA Script Level 4">
-    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
-    <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
-    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_LIST_WRAP" value="1" />
-    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="ASSIGNMENT_WRAP" value="5" />
-    <option name="WRAP_COMMENTS" value="true" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
-  </codeStyleSettings>
-  <codeStyleSettings language="JavaScript">
-    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
-    <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
-    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_LIST_WRAP" value="1" />
-    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="ASSIGNMENT_WRAP" value="5" />
-    <option name="WRAP_COMMENTS" value="true" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
-  </codeStyleSettings>
-  <codeStyleSettings language="PHP">
-    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-    <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
-    <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_LIST_WRAP" value="1" />
-    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="ASSIGNMENT_WRAP" value="5" />
-    <option name="WRAP_COMMENTS" value="true" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
-  </codeStyleSettings>
+  <option name="JD_P_AT_EMPTY_LINES" value="false" />
+  <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
+  <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
+  <option name="JD_KEEP_EMPTY_RETURN" value="false" />
 </code_scheme>
 


### PR DESCRIPTION
I don't know how well this new version interacts with newer IntelliJ and I also know it has some deficiencies like missing the "io" TLD for import sorting. But syncing from our internal version before trying to solve those issues should help in maintaining it.
