### PR TITLE
shell guide : "Parting words" from cppguide link ends with an error

### DIFF
--- a/shell.xml
+++ b/shell.xml
@@ -1141,7 +1141,7 @@ Revision 1.26
   </p>
   <p>
     Please take a few minutes to read the Parting Words section at the bottom
-    of the <a href="cppguide.xml">C++ Guide</a>.
+    of the <a href="cppguide.html">C++ Guide</a>.
   </p>
 </CATEGORY>
 


### PR DESCRIPTION
I guess html link should work.  This xml link ends up with "error on line 8 at column 8: Opening and ending tag mismatch: meta line 0 and head. Redirecting..." and no redirect ever happen.
