### PR TITLE
Reverted XML namespace name changes

### DIFF
--- a/Rguide.xml
+++ b/Rguide.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" type="text/css" href="styleguide.css"/>

--- a/pyguide.html
+++ b/pyguide.html
@@ -1,4 +1,4 @@
-<HTML xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcq="http://purl.org/dc/qualifiers/1.0/" xmlns:fo="https://www.w3.org/1999/XSL/Format" xmlns:fn="https://www.w3.org/2005/xpath-functions">
+<HTML xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcq="http://purl.org/dc/qualifiers/1.0/" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:fn="http://www.w3.org/2005/xpath-functions">
 <HEAD>
 <TITLE>Google Python Style Guide</TITLE>
 <META http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/styleguide.xsl
+++ b/styleguide.xsl
@@ -1,10 +1,10 @@
 <xsl:stylesheet version="1.0"
-xmlns:xsl="https://www.w3.org/1999/XSL/Transform"
-xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 xmlns:dc="http://purl.org/dc/elements/1.1/"
 xmlns:dcq="http://purl.org/dc/qualifiers/1.0/"
-xmlns:fo="https://www.w3.org/1999/XSL/Format"
-xmlns:fn="https://www.w3.org/2005/xpath-functions">
+xmlns:fo="http://www.w3.org/1999/XSL/Format"
+xmlns:fn="http://www.w3.org/2005/xpath-functions">
   <xsl:output method="html"/>
   <!-- Set to 1 to show explanations by default.  Set to 0 to hide them -->
   <xsl:variable name="show_explanation_default" select="0" />


### PR DESCRIPTION
8a3b573 broke all the XML guides by replacing http with https in XML namespaces.
