### PR TITLE
Fix broken link

### DIFF
--- a/shell.xml
+++ b/shell.xml
@@ -17,7 +17,7 @@ Revision 1.26
 
   <CATEGORY title="Background">
 
-    
+
 
     <STYLEPOINT title="Which Shell to Use">
       <SUMMARY>
@@ -169,7 +169,7 @@ Revision 1.26
       <p>
         Every file must have a top-level comment including a brief overview of
         its contents.
-        A 
+        A
         copyright notice
         and author information are optional.
       </p>
@@ -182,7 +182,7 @@ Revision 1.26
         </CODE_SNIPPET>
       </p>
 
-      
+
     </BODY>
   </STYLEPOINT>
 
@@ -273,7 +273,7 @@ Revision 1.26
       </p>
       <p>
         Examples:
-        
+
         <CODE_SNIPPET>
           # TODO(mrmonkey): Handle the unlikely edge cases (bug ####)
         </CODE_SNIPPET>
@@ -1141,7 +1141,7 @@ Revision 1.26
   </p>
   <p>
     Please take a few minutes to read the Parting Words section at the bottom
-    of the <a href="cppguide.xml">C++ Guide</a>.
+    of the <a href="cppguide.html">C++ Guide</a>.
   </p>
 </CATEGORY>
 


### PR DESCRIPTION
The link at the bottom of https://google.github.io/styleguide/shell.xml is
broken. When changing from `cppguide.xml` to `cppguide.html`, it works.

Also removed trailing whitespace.
