### PR TITLE
Bug-fix: NOLINT, NOLINTNEXTLINE has no affect if used for the closing-brace line "};" in the lambda declaration.

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -3884,6 +3884,14 @@ def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
       # outputting warnings for the matching closing brace, if there are
       # nested blocks with trailing semicolons, we will get the error
       # messages in reversed order.
+
+      # We need to check the line forward for NOLINT
+      raw_lines = clean_lines.raw_lines
+      ParseNolintSuppressions(filename, raw_lines[endlinenum-1], endlinenum-1,
+                              error)
+      ParseNolintSuppressions(filename, raw_lines[endlinenum], endlinenum,
+                              error)
+
       error(filename, endlinenum, 'readability/braces', 4,
             "You don't need a ; after a }")
 


### PR DESCRIPTION
Unfortunately, CppLint always prints out the error at the line "};" in the lambda declaration.
Please find the minimal not-working example below:

```
1: #include <cstdlib>
2: #include <vector>
3: #include <numeric>
4:
5: int main(int argc, char** argv) {
6:    auto mean = [](std::vector<double> const& _samples) {
7:        return
8:            std::accumulate(_samples.cbegin(), _samples.cend(), 0.0) /
9:            _samples.size();
10:    // NOLINTNEXTLINE
11:    };  // NOLINT
12:
13:   return EXIT_SUCCESS;
14: }
```

CppLint unexpectedly prints out the error _You don't need a ; after a }  [readability/braces] [4]_ for line 11 from CPP above.

This commit fixes this bug.
