### PR TITLE
Bug-fix: NOLINT, NOLINTNEXTLINE has no effect for lines like "};".

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -3884,6 +3884,14 @@ def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
       # outputting warnings for the matching closing brace, if there are
       # nested blocks with trailing semicolons, we will get the error
       # messages in reversed order.
+
+      # We need to check the line forward for NOLINT
+      raw_lines = clean_lines.raw_lines
+      ParseNolintSuppressions(filename, raw_lines[endlinenum-1], endlinenum-1,
+                              error)
+      ParseNolintSuppressions(filename, raw_lines[endlinenum], endlinenum,
+                              error)
+
       error(filename, endlinenum, 'readability/braces', 4,
             "You don't need a ; after a }")
 

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -521,6 +521,21 @@ class CpplintTest(CpplintTestBase):
                              ''],
                             error_collector)
     self.assertEquals('', error_collector.Results())
+    # NOLINT, NOLINTNEXTLINE silences the readability/braces warning for "};".
+    error_collector = ErrorCollector(self.assert_)
+    cpplint.ProcessFileData('test.cc', 'cc',
+                            ['// Copyright 2014 Your Company.',
+                             'for (int i = 0; i != 100; ++i) {',
+                             '\tstd::cout << i << std::endl;',
+                             '};  // NOLINT',
+                             'for (int i = 0; i != 100; ++i) {',
+                             '\tstd::cout << i << std::endl;',
+                             '// NOLINTNEXTLINE',
+                             '};',
+                             '//  LINT_KERNEL_FILE',
+                             ''],
+                            error_collector)
+    self.assertEquals('', error_collector.Results())
 
   # Test Variable Declarations.
   def testVariableDeclarations(self):


### PR DESCRIPTION
Unfortunately, CppLint always prints out the error for "};" regardless of NOLINT, NOLINTNEXTLINE. Please find the minimal not-working example below:

```
1: #include <cstdlib>
2: #include <iostream>
3:
4: int main(int argc, char** argv) {
5:   for (std::size_t i = 0u; i != 100u; ++i) {
6:     std::cout << i << std::endl;
10:    // NOLINTNEXTLINE
11:    };  // NOLINT
12:
13:    return EXIT_SUCCESS;
14: }
```

CppLint unexpectedly prints out the error _You don't need a ; after a }  [readability/braces] [4]_ for line 11 from CPP above.

This commit fixes this bug.
