### PR TITLE
Summarized Pull Request IntelliJ 2016

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+*.iml
+out
+gen
+.idea/

--- a/intellij-google-style.xml
+++ b/intellij-google-style.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <code_scheme name="GoogleStyle">
   <option name="JAVA_INDENT_OPTIONS">
     <value>
@@ -12,253 +11,177 @@
       <option name="USE_RELATIVE_INDENTS" value="false" />
     </value>
   </option>
+  <option name="OTHER_INDENT_OPTIONS">
+    <value>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="8" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </value>
+  </option>
+  <option name="LINE_SEPARATOR" value="&#xA;" />
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+    <value />
+  </option>
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
+      <package name="" withSubpackages="true" static="true" />
+      <emptyLine />
       <package name="com.google" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="android" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="antenna" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="antlr" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="ar" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="asposewobfuscated" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="asquare" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="atg" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="au" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="beaver" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="bibtex" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="bmsi" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="bsh" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="ccl" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="cern" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="ChartDirector" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="checkers" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="com" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="COM" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="common" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="contribs" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="corejava" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="cryptix" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="cybervillains" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="dalvik" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="danbikel" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="de" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="EDU" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="eg" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="eu" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="examples" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="fat" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="fit" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="fitlibrary" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="fmpp" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="freemarker" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="gnu" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="groovy" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="groovyjarjarantlr" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="groovyjarjarasm" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="hak" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="hep" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="ie" withSubpackages="true" static="false" />
-      <emptyLine />
+      <package name="io" withSubpackages="true" static="false" />
       <package name="imageinfo" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="info" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="it" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jal" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="Jama" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="japa" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="japacheckers" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jas" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jasmin" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="javancss" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="javanet" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="javassist" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="javazoom" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="java_cup" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jcifs" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jetty" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="JFlex" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jj2000" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jline" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jp" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="JSci" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jsr166y" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="junit" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jxl" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="jxxload_help" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="kawa" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="kea" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="libcore" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="libsvm" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="lti" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="memetic" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="mt" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="mx4j" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="net" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="netscape" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="nl" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="nu" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="oauth" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="ognl" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="opennlp" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="oracle" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="org" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="penn2dg" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="pennconverter" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="pl" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="prefuse" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="proguard" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="repackage" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="scm" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="se" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="serp" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="simple" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="soot" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="sqlj" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="src" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="ssa" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="sun" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="sunlabs" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="tcl" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="testdata" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="testshell" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="testsuite" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="twitter4j" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="uk" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="ViolinStrings" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="weka" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="wet" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="winstone" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="woolfel" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="wowza" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="java" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="javax" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="true" />
     </value>
   </option>
+  <option name="STATIC_METHODS_ORDER_WEIGHT" value="5" />
+  <option name="METHODS_ORDER_WEIGHT" value="4" />
   <option name="RIGHT_MARGIN" value="100" />
+  <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
+  <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+  <option name="JD_ADD_BLANK_AFTER_DESCRIPTION" value="false" />
   <option name="JD_P_AT_EMPTY_LINES" value="false" />
   <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
   <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
   <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+  <option name="HTML_KEEP_BLANK_LINES" value="1" />
+  <option name="HTML_ALIGN_TEXT" value="true" />
+  <option name="KEEP_LINE_BREAKS" value="false" />
+  <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
   <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+  <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
   <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+  <option name="BLANK_LINES_AROUND_CLASS" value="0" />
+  <option name="BLANK_LINES_AROUND_FIELD" value="1" />
   <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
+  <option name="BRACE_STYLE" value="2" />
+  <option name="CLASS_BRACE_STYLE" value="2" />
+  <option name="METHOD_BRACE_STYLE" value="2" />
+  <option name="ELSE_ON_NEW_LINE" value="true" />
+  <option name="WHILE_ON_NEW_LINE" value="true" />
+  <option name="CATCH_ON_NEW_LINE" value="true" />
+  <option name="FINALLY_ON_NEW_LINE" value="true" />
   <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
   <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
   <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
@@ -267,7 +190,15 @@
   <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
   <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
   <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+  <option name="SPACE_AFTER_TYPE_CAST" value="false" />
+  <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
+  <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="false" />
+  <option name="SPACE_BEFORE_FOR_PARENTHESES" value="false" />
+  <option name="SPACE_BEFORE_CATCH_PARENTHESES" value="false" />
+  <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="false" />
+  <option name="SPACE_BEFORE_SYNCHRONIZED_PARENTHESES" value="false" />
   <option name="CALL_PARAMETERS_WRAP" value="1" />
+  <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
   <option name="METHOD_PARAMETERS_WRAP" value="1" />
   <option name="EXTENDS_LIST_WRAP" value="1" />
   <option name="THROWS_LIST_WRAP" value="1" />
@@ -286,114 +217,45 @@
   <option name="DOWHILE_BRACE_FORCE" value="3" />
   <option name="WHILE_BRACE_FORCE" value="3" />
   <option name="FOR_BRACE_FORCE" value="3" />
-  <ADDITIONAL_INDENT_OPTIONS fileType="css">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
+  <JavaCodeStyleSettings>
+    <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
+    <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
+  </JavaCodeStyleSettings>
+  <MarkdownNavigatorCodeStyleSettings>
+    <option name="RIGHT_MARGIN" value="72" />
+  </MarkdownNavigatorCodeStyleSettings>
+  <XML>
+    <option name="XML_KEEP_BLANK_LINES" value="1" />
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+  </XML>
   <ADDITIONAL_INDENT_OPTIONS fileType="haml">
     <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
   </ADDITIONAL_INDENT_OPTIONS>
   <ADDITIONAL_INDENT_OPTIONS fileType="java">
     <option name="INDENT_SIZE" value="2" />
     <option name="CONTINUATION_INDENT_SIZE" value="4" />
     <option name="TAB_SIZE" value="8" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
   </ADDITIONAL_INDENT_OPTIONS>
   <ADDITIONAL_INDENT_OPTIONS fileType="js">
-    <option name="INDENT_SIZE" value="4" />
     <option name="CONTINUATION_INDENT_SIZE" value="4" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="jsp">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="php">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
   </ADDITIONAL_INDENT_OPTIONS>
   <ADDITIONAL_INDENT_OPTIONS fileType="sass">
     <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
-  </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="xml">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
   </ADDITIONAL_INDENT_OPTIONS>
   <ADDITIONAL_INDENT_OPTIONS fileType="yml">
     <option name="INDENT_SIZE" value="2" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
   </ADDITIONAL_INDENT_OPTIONS>
   <codeStyleSettings language="ECMA Script Level 4">
-    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
     <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
     <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
     <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
     <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
     <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_PARAMETERS_WRAP" value="1" />
     <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_LIST_WRAP" value="1" />
     <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="1" />
     <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
     <option name="BINARY_OPERATION_WRAP" value="1" />
     <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
@@ -409,24 +271,42 @@
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
   </codeStyleSettings>
-  <codeStyleSettings language="JavaScript">
+  <codeStyleSettings language="JAVA">
+    <option name="RIGHT_MARGIN" value="100" />
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
-    <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
-    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_PARAMETERS_WRAP" value="1" />
     <option name="EXTENDS_LIST_WRAP" value="1" />
     <option name="THROWS_LIST_WRAP" value="1" />
     <option name="EXTENDS_KEYWORD_WRAP" value="1" />
     <option name="THROWS_KEYWORD_WRAP" value="1" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="5" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="8" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="JavaScript">
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+    <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
     <option name="BINARY_OPERATION_WRAP" value="1" />
     <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
@@ -471,6 +351,15 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </indentOptions>
   </codeStyleSettings>
 </code_scheme>
-


### PR DESCRIPTION
This removes tags from the style file that are no longer being read by IntelliJ, and adds them back in the new format. Without this change, it's not even possible to use the style file in IntelliJ 15 or later, since most of the old tags are not being read by the IDE.

After merging my PR all Google Styleguides should work for IntelliJ 2016.X onwards.

This Pull Request fixes (I hope):

Issue #26 Static imports imported first, pull request #49
Issue #69 intellij-java-google-style.xml was not applied correctly for Idea 14
Pull Request #58 Add package tld io to intellij import layout.
Pull Request #120 Adding io.\* to IMPORT_LAYOUT_TABLE in IntelliJ style
Pull Request #115 Sync Java IDE styles with internal configuration
Pull Request #96 Modernize IntelliJ style file
Pull Request #75 Add Java code style for IntelliJ 15
Would be great if someone merges this into the gh-pages branch
