### PR TITLE
Update shebang line

### DIFF
--- a/pyguide.html
+++ b/pyguide.html
@@ -1506,9 +1506,8 @@ No:  <span class="external"></span>def foo(a, b=FLAGS.my_thing):  # sys.argv has
         Most <code>.py</code> files do not need to start with a
         <code>#!</code> line.  Start the main file of a
          program with
-        <code>#!/usr/bin/python</code> with an optional single digit
-        <code>2</code> or <code>3</code> suffix per
-        <a href="https://www.python.org/dev/peps/pep-0394/">PEP-394</a>.
+        <code>#!/usr/bin/env python</code> with an optional single digit
+        <code>2</code> or <code>3</code> suffix.
       </DIV>
       <DIV class=""><DIV class="stylepoint_body" name="Shebang_Line__body" id="Shebang_Line__body" style="display: none">
         


### PR DESCRIPTION
This shebang line is more portable, as the user may not have python installed in /usr/local/bin/python. Also, according to PEP 486, the line makes the Python Launcher aware of virtual environments.
