### PR TITLE
Fix spelling of errormessage in argument parsing

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -6078,7 +6078,7 @@ def ParseArguments(args):
       try:
           _valid_extensions = set(val.split(','))
       except ValueError:
-          PrintUsage('Extensions must be comma seperated list.')
+          PrintUsage('Extensions must be comma separated list.')
 
   if not filenames:
     PrintUsage('No files were specified.')


### PR DESCRIPTION
Trivial fix of a typo in one of the possible errormessage from `ParseArguments()`.
