### PR TITLE
Support C++11 types in build/include_what_you_use

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5262,12 +5262,15 @@ _HEADERS_CONTAINING_TEMPLATES = (
     ('<limits>', ('numeric_limits',)),
     ('<list>', ('list',)),
     ('<map>', ('map', 'multimap',)),
-    ('<memory>', ('allocator',)),
+    ('<memory>', ('allocator', 'make_shared', 'make_unique', 'shared_ptr',
+                  'unique_ptr', 'weak_ptr')),
     ('<queue>', ('queue', 'priority_queue',)),
     ('<set>', ('set', 'multiset',)),
     ('<stack>', ('stack',)),
     ('<string>', ('char_traits', 'basic_string',)),
     ('<tuple>', ('tuple',)),
+    ('<unordered_map>', ('unordered_map', 'unordered_multimap')),
+    ('<unordered_set>', ('unordered_set', 'unordered_multiset')),
     ('<utility>', ('pair',)),
     ('<vector>', ('vector',)),
 
@@ -5282,7 +5285,7 @@ _HEADERS_MAYBE_TEMPLATES = (
     ('<algorithm>', ('copy', 'max', 'min', 'min_element', 'sort',
                      'transform',
                     )),
-    ('<utility>', ('swap',)),
+    ('<utility>', ('forward', 'make_pair', 'move', 'swap')),
     )
 
 _RE_PATTERN_STRING = re.compile(r'\bstring\b')

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -911,6 +911,12 @@ class CpplintTest(CpplintTestBase):
         'Add #include <utility> for pair<>'
         '  [build/include_what_you_use] [4]')
     self.TestIncludeWhatYouUse(
+        """#include <hash_map>
+           auto foo = std::make_pair(1, 2);
+        """,
+        'Add #include <utility> for make_pair'
+        '  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
         """#include <utility>
            std::pair<int,int> foo;
         """,
@@ -998,6 +1004,18 @@ class CpplintTest(CpplintTestBase):
         'Add #include <map> for multimap<>'
         '  [build/include_what_you_use] [4]')
     self.TestIncludeWhatYouUse(
+        """#include <string>
+           void a(const std::unordered_map<int,string> &foobar);
+        """,
+        'Add #include <unordered_map> for unordered_map<>'
+        '  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
+        """#include <string>
+           void a(const std::unordered_set<int> &foobar);
+        """,
+        'Add #include <unordered_set> for unordered_set<>'
+        '  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
         """#include <queue>
            void a(const std::priority_queue<int> &foobar);
         """,
@@ -1020,6 +1038,31 @@ class CpplintTest(CpplintTestBase):
            int i = numeric_limits<int>::max()
         """,
         '')
+    self.TestIncludeWhatYouUse(
+        """#include <string>
+           std::unique_ptr<int> x;
+        """,
+        'Add #include <memory> for unique_ptr<>'
+        '  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
+        """#include <string>
+           auto x = std::make_unique<int>(0);
+        """,
+        'Add #include <memory> for make_unique<>'
+        '  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
+        """#include <vector>
+           vector<int> foo(vector<int> x) { return std::move(x); }
+        """,
+        'Add #include <utility> for move'
+        '  [build/include_what_you_use] [4]')
+    self.TestIncludeWhatYouUse(
+        """#include <string>
+           int a, b;
+           std::swap(a, b);
+        """,
+        'Add #include <utility> for swap'
+        '  [build/include_what_you_use] [4]')
 
     # Test the UpdateIncludeState code path.
     mock_header_contents = ['#include "blah/foo.h"', '#include "blah/bar.h"']


### PR DESCRIPTION
This change adds support for forward, make_pair, make_shared,,
make_unique, move, shared_ptr, unique_ptr, unordered_map,
unordered_multimap, unordered_multiset, unordered_set, weak_ptr.
Closes #133.
