### PR TITLE
Fix the `cpplint.py` `build/endif_comment` check.

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -2683,6 +2683,11 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
            filename, line number, error level, and message
   """
 
+  line = clean_lines.lines_without_raw_strings[linenum]
+  if Match(r'\s*#\s*endif\s*([^/\s]|/[^/]|$)', line):
+    error(filename, linenum, 'build/endif_comment', 5,
+          'Uncommented text after #endif is non-standard.  Use a comment.')
+
   # Remove comments from the line, but leave in strings for now.
   line = clean_lines.lines[linenum]
 
@@ -2712,10 +2717,6 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
     error(filename, linenum, 'build/storage_class', 5,
           'Storage-class specifier (static, extern, typedef, etc) should be '
           'at the beginning of the declaration.')
-
-  if Match(r'\s*#\s*endif\s*[^/\s]+', line):
-    error(filename, linenum, 'build/endif_comment', 5,
-          'Uncommented text after #endif is non-standard.  Use a comment.')
 
   if Match(r'\s*class\s+(\w+\s*::\s*)+\w+\s*;', line):
     error(filename, linenum, 'build/forward_decl', 5,

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -3754,7 +3754,7 @@ class CpplintTest(CpplintTestBase):
         #else
           baz;
           qux;
-        #endif""",
+        #endif  // foo""",
         '')
     self.TestMultiLineLint(
         """void F() {
@@ -3910,7 +3910,7 @@ class CpplintTest(CpplintTestBase):
                              '#include "path/unique.h"',
                              '#else',
                              '#include "path/unique.h"',
-                             '#endif',
+                             '#endif  // MACRO',
                              ''],
                             error_collector)
     self.assertEquals(
@@ -3959,7 +3959,7 @@ class CpplintTest(CpplintTestBase):
           struct Foo : public Goo {
         #else
           struct Foo : public Hoo {
-        #endif
+        #endif  // DERIVE_FROM_GOO
           };""",
         '')
     self.TestMultiLineLint(
@@ -3969,7 +3969,7 @@ class CpplintTest(CpplintTestBase):
           : public Goo {
         #else
           : public Hoo {
-        #endif
+        #endif  // DERIVE_FROM_GOO
         };""",
         '')
     # Test incomplete class
@@ -3986,6 +3986,27 @@ class CpplintTest(CpplintTestBase):
         #endif Not a comment""",
         'Uncommented text after #endif is non-standard.  Use a comment.'
         '  [build/endif_comment] [5]')
+
+    correct_lines = [
+      '#endif  // text',
+      '#endif  //'
+    ]
+
+    for line in correct_lines:
+      self.TestLint(line, '')
+
+    incorrect_lines = [
+      '#endif',
+      '#endif Not a comment',
+      '#endif / One `/` is not enough to start a comment'
+    ]
+
+    for line in incorrect_lines:
+      self.TestLint(
+        line,
+        'Uncommented text after #endif is non-standard.  Use a comment.'
+        '  [build/endif_comment] [5]')
+
 
   def testBuildForwardDecl(self):
     # The crosstool compiler we currently use will fail to compile the


### PR DESCRIPTION
- The check needs to be run before we remove comments, otherwise valid
  lines will be found as invalid.
- A single character different from `/` after the spaces is enough to
  indicate an error.
- Also catch errors when only one `/` is present.
  (For example `#endif / MY_FILE_H`.)

Tested with:

```
// Correct

#endif// FOO_1
#endif // FOO_2
#endif  // FOO_3
#endif  //
#endif  // blargh
#endif  // one tab
#endif      // two tabs

// Incorrect
// Note that there are spaces and tabs below.
#endif
#endif 
#endif          
#endif  
#endif                          
#endif x
#endif xxx
#endif / xxx
```
