### PR TITLE
Java indent configuration by fileType use JAVA key instead of java

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -306,7 +306,7 @@
     <option name="LABEL_INDENT_ABSOLUTE" value="false" />
     <option name="USE_RELATIVE_INDENTS" value="false" />
   </ADDITIONAL_INDENT_OPTIONS>
-  <ADDITIONAL_INDENT_OPTIONS fileType="java">
+  <ADDITIONAL_INDENT_OPTIONS fileType="JAVA">
     <option name="INDENT_SIZE" value="2" />
     <option name="CONTINUATION_INDENT_SIZE" value="4" />
     <option name="TAB_SIZE" value="8" />


### PR DESCRIPTION
The filetype java is not working anymore with Intellij 2016.2.
