### PR TITLE
Extended CStyleCast regular expressions

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5107,8 +5107,11 @@ def CheckCasts(filename, clean_lines, linenum, error):
             matched_type)
 
   if not expecting_function:
+    # This doesn't check for short, long, or long long integer casts because
+    # they are disallowed by other lint rules.
     CheckCStyleCast(filename, clean_lines, linenum, 'static_cast',
-                    r'\((int|float|double|bool|char|u?int(16|32|64))\)', error)
+                    r'\((unsigned|(unsigned )?(char|int)|float|double|bool|'
+                    r'u?int(8|16|32|64)(_t)?)\)', error)
 
   # This doesn't catch all cases. Consider (const char * const)"hello".
   #
@@ -5120,7 +5123,7 @@ def CheckCasts(filename, clean_lines, linenum, error):
   else:
     # Check pointer casts for other than string constants
     CheckCStyleCast(filename, clean_lines, linenum, 'reinterpret_cast',
-                    r'\((\w+\s?\*+\s?)\)', error)
+                    r'\(((const )?\w+\s?\*+\s?(const)?)\)', error)
 
   # In addition, we look for people taking the address of a cast.  This
   # is dangerous -- casts can assign to temporaries, so the pointer doesn't

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -561,23 +561,26 @@ class CpplintTest(CpplintTestBase):
         'int a = (int)-1.0;',
         'Using C-style cast.  Use static_cast<int>(...) instead'
         '  [readability/casting] [4]')
-    self.TestLint(
-        'int *a = (int *)NULL;',
-        'Using C-style cast.  Use reinterpret_cast<int *>(...) instead'
-        '  [readability/casting] [4]')
 
-    self.TestLint(
-        'uint16 a = (uint16)1.0;',
-        'Using C-style cast.  Use static_cast<uint16>(...) instead'
-        '  [readability/casting] [4]')
-    self.TestLint(
-        'int32 a = (int32)1.0;',
-        'Using C-style cast.  Use static_cast<int32>(...) instead'
-        '  [readability/casting] [4]')
-    self.TestLint(
-        'uint64 a = (uint64)1.0;',
-        'Using C-style cast.  Use static_cast<uint64>(...) instead'
-        '  [readability/casting] [4]')
+    cast_types = ['int *', 'int* ', 'const int *', 'const int* ',
+                  'const int * const', 'const int* const']
+    for cast_type in cast_types:
+      self.TestLint(
+          cast_type + 'a = (' + cast_type.rstrip() + ')NULL;',
+          'Using C-style cast.  Use reinterpret_cast<' + cast_type.rstrip() +
+          '>(...) instead  [readability/casting] [4]')
+
+    cast_types = ['unsigned', 'unsigned char', 'char', 'unsigned int', 'int',
+                  'float', 'double', 'bool',
+                  'uint8', 'uint8_t', 'int8', 'int8_t',
+                  'uint16', 'uint16_t', 'int16', 'int16_t',
+                  'uint32', 'uint32_t', 'int32', 'int32_t',
+                  'uint64', 'uint64_t', 'int64', 'int64_t']
+    for cast_type in cast_types:
+      self.TestLint(
+          cast_type + ' a = (' + cast_type + ')1.0;',
+          'Using C-style cast.  Use static_cast<' + cast_type + '>(...) instead'
+          '  [readability/casting] [4]')
 
     # These shouldn't be recognized casts.
     self.TestLint('u a = (u)NULL;', '')


### PR DESCRIPTION
The current static_cast regular expression now also checks for "unsigned", "unsigned char", "unsigned int", and the types in stdint.h (e.g., uint8_t). The reinterpret_cast regular expression now also checks for const qualified pointers.

The unit test coverage for both regular expressions was also improved.
