### PR TITLE
Cpplint is unnecessarily polluting stderr

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -909,7 +909,7 @@ class _CppLintState(object):
     for category, count in self.errors_by_category.iteritems():
       sys.stderr.write('Category \'%s\' errors found: %d\n' %
                        (category, count))
-    sys.stderr.write('Total errors found: %d\n' % self.error_count)
+    sys.stdout.write('Total errors found: %d\n' % self.error_count)
 
 _cpplint_state = _CppLintState()
 
@@ -6004,7 +6004,7 @@ def ProcessFile(filename, vlevel, extra_check_functions=[]):
         Error(filename, linenum, 'whitespace/newline', 1,
               'Unexpected \\r (^M) found; better to use only \\n')
 
-  sys.stderr.write('Done processing %s\n' % filename)
+  sys.stdout.write('Done processing %s\n' % filename)
   _RestoreFilters()
 
 


### PR DESCRIPTION
This solves #181.
Allows to separate errors and normal output into separate streams.
Useful when standard output is to be redirected to /dev/null leaving
only errors.
