### PR TITLE
Revert "Fix the `cpplint.py` `build/endif_comment` check."

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -2710,11 +2710,6 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
            filename, line number, error level, and message
   """
 
-  line = clean_lines.lines_without_raw_strings[linenum]
-  if Match(r'\s*#\s*endif\s*([^/\s]|/[^/]|$)', line):
-    error(filename, linenum, 'build/endif_comment', 5,
-          'Uncommented text after #endif is non-standard.  Use a comment.')
-
   # Remove comments from the line, but leave in strings for now.
   line = clean_lines.lines[linenum]
 
@@ -2744,6 +2739,10 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
     error(filename, linenum, 'build/storage_class', 5,
           'Storage-class specifier (static, extern, typedef, etc) should be '
           'at the beginning of the declaration.')
+
+  if Match(r'\s*#\s*endif\s*[^/\s]+', line):
+    error(filename, linenum, 'build/endif_comment', 5,
+          'Uncommented text after #endif is non-standard.  Use a comment.')
 
   if Match(r'\s*class\s+(\w+\s*::\s*)+\w+\s*;', line):
     error(filename, linenum, 'build/forward_decl', 5,

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -3754,7 +3754,7 @@ class CpplintTest(CpplintTestBase):
         #else
           baz;
           qux;
-        #endif  // foo""",
+        #endif""",
         '')
     self.TestMultiLineLint(
         """void F() {
@@ -3920,7 +3920,7 @@ class CpplintTest(CpplintTestBase):
                              '#include "path/unique.h"',
                              '#else',
                              '#include "path/unique.h"',
-                             '#endif  // MACRO',
+                             '#endif',
                              ''],
                             error_collector)
     self.assertEquals(
@@ -3969,7 +3969,7 @@ class CpplintTest(CpplintTestBase):
           struct Foo : public Goo {
         #else
           struct Foo : public Hoo {
-        #endif  // DERIVE_FROM_GOO
+        #endif
           };""",
         '')
     self.TestMultiLineLint(
@@ -3979,7 +3979,7 @@ class CpplintTest(CpplintTestBase):
           : public Goo {
         #else
           : public Hoo {
-        #endif  // DERIVE_FROM_GOO
+        #endif
         };""",
         '')
     # Test incomplete class
@@ -3996,27 +3996,6 @@ class CpplintTest(CpplintTestBase):
         #endif Not a comment""",
         'Uncommented text after #endif is non-standard.  Use a comment.'
         '  [build/endif_comment] [5]')
-
-    correct_lines = [
-      '#endif  // text',
-      '#endif  //'
-    ]
-
-    for line in correct_lines:
-      self.TestLint(line, '')
-
-    incorrect_lines = [
-      '#endif',
-      '#endif Not a comment',
-      '#endif / One `/` is not enough to start a comment'
-    ]
-
-    for line in incorrect_lines:
-      self.TestLint(
-        line,
-        'Uncommented text after #endif is non-standard.  Use a comment.'
-        '  [build/endif_comment] [5]')
-
 
   def testBuildForwardDecl(self):
     # The crosstool compiler we currently use will fail to compile the


### PR DESCRIPTION
Reverts google/styleguide#169

Should fix #186.
