### PR TITLE
Remove default list kwarg in `cpplint.py`

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5703,7 +5703,7 @@ def CheckItemIndentationInNamespace(filename, raw_lines_no_comments, linenum,
 
 def ProcessLine(filename, file_extension, clean_lines, line,
                 include_state, function_state, nesting_state, error,
-                extra_check_functions=[]):
+                extra_check_functions=None):
   """Processes a single line in the file.
 
   Args:
@@ -5722,6 +5722,8 @@ def ProcessLine(filename, file_extension, clean_lines, line,
                            run on each source line. Each function takes 4
                            arguments: filename, clean_lines, line, error
   """
+  if extra_check_functions is None:
+    extra_check_functions = []
   raw_lines = clean_lines.raw_lines
   ParseNolintSuppressions(filename, raw_lines[line], line, error)
   nesting_state.Update(filename, clean_lines, line, error)
@@ -5817,7 +5819,7 @@ def FlagCxx14Features(filename, clean_lines, linenum, error):
 
 
 def ProcessFileData(filename, file_extension, lines, error,
-                    extra_check_functions=[]):
+                    extra_check_functions=None):
   """Performs lint checks and reports any errors to the given error function.
 
   Args:
@@ -5831,6 +5833,8 @@ def ProcessFileData(filename, file_extension, lines, error,
                            run on each source line. Each function takes 4
                            arguments: filename, clean_lines, line, error
   """
+  if extra_check_functions is None:
+    extra_check_functions = []
   lines = (['// marker so line numbers and indices both start at 1'] + lines +
            ['// marker so line numbers end in a known way'])
 
@@ -5948,7 +5952,7 @@ def ProcessConfigOverrides(filename):
   return True
 
 
-def ProcessFile(filename, vlevel, extra_check_functions=[]):
+def ProcessFile(filename, vlevel, extra_check_functions=None):
   """Does google-lint on a single file.
 
   Args:
@@ -5961,7 +5965,8 @@ def ProcessFile(filename, vlevel, extra_check_functions=[]):
                            run on each source line. Each function takes 4
                            arguments: filename, clean_lines, line, error
   """
-
+  if extra_check_functions is None:
+    extra_check_functions = []
   _SetVerboseLevel(vlevel)
   _BackupFilters()
 


### PR DESCRIPTION
As identified in #201, this change removes the default list params in several functions and prefers the paradigm:

    def foo(x=None):
        if x is None:
            x = []
        ...