### PR TITLE
cpplint: allow using-directive for user-defined literals namespaces

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -4708,7 +4708,15 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
           'Did you mean "memset(%s, 0, %s)"?'
           % (match.group(1), match.group(2)))
 
-  if Search(r'\busing namespace\b', line):
+  # Check for 'using namespace' which pollutes namespaces.
+  # An exception is made for namespaces with the word 'literals',
+  # such namespaces are likely to only contain user-defined literals
+  # which by design are supposed to be imported by using-directives,
+  # e.g. 'using namespace std::chrono_literals;'.
+  # Headers do not take part of this 'literals' exception.
+  match = Search(r'\busing namespace\s+((\w|::)+)', line)
+  if (match and
+      (IsHeaderExtension(file_extension) or 'literals' not in match.group(1))):
     error(filename, linenum, 'build/namespaces', 5,
           'Do not use namespace using-directives.  '
           'Use using-declarations instead.')

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -3023,19 +3023,23 @@ class CpplintTest(CpplintTestBase):
   # precise, the '// marker so line numbers and indices both start at
   # 1' line was also causing the issue.
   def testLinePrecededByEmptyOrCommentLines(self):
-    def DoTest(self, lines):
+    def DoTest(self, filetype, lines, error_count):
       error_collector = ErrorCollector(self.assert_)
-      cpplint.ProcessFileData('foo.cc', 'cc', lines, error_collector)
+      cpplint.ProcessFileData('foo.' + filetype, filetype, lines,
+                              error_collector)
       # The warning appears only once.
       self.assertEquals(
-          1,
+          error_count,
           error_collector.Results().count(
               'Do not use namespace using-directives.  '
               'Use using-declarations instead.'
               '  [build/namespaces] [5]'))
-    DoTest(self, ['using namespace foo;'])
-    DoTest(self, ['', '', '', 'using namespace foo;'])
-    DoTest(self, ['// hello', 'using namespace foo;'])
+    DoTest(self, 'cc', ['using namespace foo;'], 1)
+    DoTest(self, 'h', ['using namespace foo;'], 1)
+    DoTest(self, 'cc', ['', '', '', 'using namespace foo;'], 1)
+    DoTest(self, 'cc', ['// hello', 'using namespace foo;'], 1)
+    DoTest(self, 'cc', ['using namespace std::chrono_literals;'], 0)
+    DoTest(self, 'h', ['using namespace std::chrono_literals;'], 1)
 
   def testNewlineAtEOF(self):
     def DoTest(self, data, is_missing_eof):


### PR DESCRIPTION
This change adds an exception to the `using namespace` directives check,
to allow user-defined literals namespaces for source files (not headers).

- http://en.cppreference.com/w/cpp/chrono/operator%22%22h