### PR TITLE
Use raw.githubusercontent.com over cdn.rawgit.com

### DIFF
--- a/include/jsguide.js
+++ b/include/jsguide.js
@@ -50,7 +50,6 @@ window.initStyleGuide = function(init) {
 
   // Call the pretty-printer after we've fixed up the code blocks.
   var pretty = document.createElement('script');
-  pretty.src = 'https://cdn.rawgit.com/google/code-prettify/master/loader/' +
-      'run_prettify.js';
+  pretty.src = 'https://raw.githubusercontent.com/google/code-prettify/master/loader/run_prettify.js';
   document.body.appendChild(pretty);
 }.bind(null, window.initStyleGuide);

--- a/javaguide.html
+++ b/javaguide.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" type="text/css" href="javaguide.css">
 <script language="javascript" src="include/styleguide.js"></script>
 <link rel="shortcut icon" type="image/x-icon" href="https://www.google.com/favicon.ico" />
-<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
+<script src="https://raw.githubusercontent.com/google/code-prettify/master/loader/run_prettify.js"></script>
 </head>
 <body onload="initStyleGuide();">
 <div id="content">


### PR DESCRIPTION
Fixes up Java and JS guides.