### PR TITLE
cpplint: Decode filename path

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -51,6 +51,7 @@ import sre_compile
 import string
 import sys
 import unicodedata
+import locale
 
 
 _USAGE = """
@@ -5370,6 +5371,7 @@ def FilesBelongToSameModule(filename_cc, filename_h):
   fileinfo = FileInfo(filename_cc)
   if not fileinfo.IsSource():
     return (False, '')
+  filename_cc = filename_cc.decode(locale.getpreferredencoding())
   filename_cc = filename_cc[:-len(fileinfo.Extension())]
   matched_test_suffix = Search(_TEST_FILE_SUFFIX, fileinfo.BaseName())
   if matched_test_suffix:


### PR DESCRIPTION
While waiting for official python3 support,
enable (troublefree) usage of pylint in paths
containing non-ascii characters.

Use local preferred encoding to make a qualified
guess of what the local locale is...