### PR TITLE
Fix false positive alarms on missed <algortihm> or <utility> header.

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -169,8 +169,8 @@ Syntax: cpplint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
 
     The "root" option is similar in function to the --root flag (see example
     above).
-    
-    The "headers" option is similar in function to the --headers flag 
+
+    The "headers" option is similar in function to the --headers flag
     (see example above).
 
     CPPLINT.cfg has an effect on files in the same directory and all
@@ -5323,7 +5323,22 @@ for _header, _templates in _HEADERS_MAYBE_TEMPLATES:
     # Match max<type>(..., ...), max(..., ...), ::max(..., ...) but not
     # foo->max, foo.max or type::max().
     _re_pattern_headers_maybe_templates.append(
-        (re.compile(r'[^>.](?<!\w::)\b' + _template + r'(<.*?>)?\([^\)]'),
+        (re.compile(r"""
+                    (
+                    \bstd:: | # starts with std::
+                    [(+\-=?%^&*/\[] | # used in arithmetic expression or ternary conditional operator
+                    [^:]: | # the second part of ternary conditional operator
+                    ^ # or just the start of the line
+                    ) [\s]* # possibly we have spaces
+                    """ + _template +
+                    r"""
+                    (
+                    [\s]* # possibly, spaces
+                    <.*?> # the arguments for the template
+                    )? # we can omit the template part
+                    [\s]* #spaces
+                    \( [^\)] # after function we should have opening brace
+                    """, re.X),
             _template,
             _header))
 

--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5320,10 +5320,10 @@ _RE_PATTERN_STRING = re.compile(r'\bstring\b')
 _re_pattern_headers_maybe_templates = []
 for _header, _templates in _HEADERS_MAYBE_TEMPLATES:
   for _template in _templates:
-    # Match max<type>(..., ...), max(..., ...), but not foo->max, foo.max or
-    # type::max().
+    # Match max<type>(..., ...), max(..., ...), ::max(..., ...) but not
+    # foo->max, foo.max or type::max().
     _re_pattern_headers_maybe_templates.append(
-        (re.compile(r'[^>.]\b' + _template + r'(<.*?>)?\([^\)]'),
+        (re.compile(r'[^>.](?<!\w::)\b' + _template + r'(<.*?>)?\([^\)]'),
             _template,
             _header))
 


### PR DESCRIPTION
The case of a non-STL realization of the one of the functions under test that
is called via class name/namespace resolution syntax (e.g. type type::min)
was not handled by the regular expression.

Fixes the #174
@rakhimov, please check if this fix solves your case. 