### PR TITLE
Add the tokens `signed` and `unsigned` to the definition of a type.

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -4588,7 +4588,8 @@ def _GetTextInside(text, start_pattern):
 #   >
 _RE_PATTERN_IDENT = r'[_a-zA-Z]\w*'  # =~ [[:alpha:]][[:alnum:]]*
 _RE_PATTERN_TYPE = (
-    r'(?:const\s+)?(?:typename\s+|class\s+|struct\s+|union\s+|enum\s+)?'
+    r'(?:const\s+)?(?:typename\s+|class\s+|struct\s+|union\s+|enum\s+'
+    r'|signed\s+|unsigned\s+)?'
     r'(?:\w|'
     r'\s*<(?:<(?:<[^<>]*>|[^<>])*>|[^<>])*>|'
     r'::)+')

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -2203,6 +2203,9 @@ class CpplintTest(CpplintTestBase):
     self.TestLint('istringstream& LogFunc(istringstream& s);', '')
     # Returning a non-const reference from a function is OK.
     self.TestLint('int& g();', '')
+    # Passing signed or unsigned const references is OK.
+    self.TestLint('void foo(const unsigned int& bar);', '');
+    self.TestLint('void foo(const signed int& bar);', '');
     # Passing a const reference to a struct (using the struct keyword) is OK.
     self.TestLint('void foo(const struct tm& tm);', '')
     # Passing a const reference to a typename is OK.


### PR DESCRIPTION
Add the tokens `signed` and `unsigned` as part of the definition of a type.