### PR TITLE
Use lowercase example in import

### DIFF
--- a/pyguide.html
+++ b/pyguide.html
@@ -2009,7 +2009,7 @@ Don'<span class="external"></span>t do this.
 <span class="external"></span>import foo
 <span class="external"></span>from foo import bar
 <span class="external"></span>from foo.bar import baz
-<span class="external"></span>from foo.bar import Quux
+<span class="external"></span>from foo.bar import quux
 <span class="external"></span>from Foob import ar</PRE></DIV>
     
     


### PR DESCRIPTION
This was probably there to illustrate the case insensitivity, but since importing classes is not allowed, this example is misleading.