### PR TITLE
Teach the explicit constructor check about constexpr.

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -2779,7 +2779,8 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
   # Look for single-argument constructors that aren't marked explicit.
   # Technically a valid construct, but against style.
   explicit_constructor_match = Match(
-      r'\s+(?:inline\s+)?(explicit\s+)?(?:inline\s+)?%s\s*'
+      r'\s+(?:(?:inline|constexpr)\s+)*(explicit\s+)?'
+      r'(?:(?:inline|constexpr)\s+)*%s\s*'
       r'\(((?:[^()]|\([^()]*\))*)\)'
       % re.escape(base_classname),
       line)

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -1316,6 +1316,80 @@ class CpplintTest(CpplintTestBase):
           };""",
           'Single-parameter constructors should be marked explicit.'
           '  [runtime/explicit] [5]')
+      # missing explicit for constexpr constructors is bad as well
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            constexpr Foo(int f);
+          };""",
+          'Single-parameter constructors should be marked explicit.'
+          '  [runtime/explicit] [5]')
+      # missing explicit for constexpr+inline constructors is bad as well
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            constexpr inline Foo(int f);
+          };""",
+          'Single-parameter constructors should be marked explicit.'
+          '  [runtime/explicit] [5]')
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            inline constexpr Foo(int f);
+          };""",
+          'Single-parameter constructors should be marked explicit.'
+          '  [runtime/explicit] [5]')
+      # explicit with inline is accepted
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            inline explicit Foo(int f);
+          };""",
+          '')
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            explicit inline Foo(int f);
+          };""",
+          '')
+      # explicit with constexpr is accepted
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            constexpr explicit Foo(int f);
+          };""",
+          '')
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            explicit constexpr Foo(int f);
+          };""",
+          '')
+      # explicit with constexpr+inline is accepted
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            inline constexpr explicit Foo(int f);
+          };""",
+          '')
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            explicit inline constexpr Foo(int f);
+          };""",
+          '')
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            constexpr inline explicit Foo(int f);
+          };""",
+          '')
+      self.TestMultiLineLint(
+          """
+          class Foo {
+            explicit constexpr inline Foo(int f);
+          };""",
+          '')
       # structs are caught as well.
       self.TestMultiLineLint(
           """


### PR DESCRIPTION
If a constructor is marked constexpr it evades the explicit constructor
check right now, since the check only knows about the inline keyword.
Teach it that constexpr can be used also.