### PR TITLE
Fix indentation check for access keywords

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -2596,7 +2596,7 @@ class NestingState(object):
         # check if the keywords are not preceded by whitespaces.
         indent = access_match.group(1)
         if (len(indent) != classinfo.class_indent + 1 and
-            Match(r'^\s*$', indent)):
+            Match(r'^\s+$', indent)):
           if classinfo.is_struct:
             parent = 'struct ' + classinfo.name
           else:


### PR DESCRIPTION
No whitespace before the access keywords in class/struct declarations
should be acceptable. The behavior of the check correctly reflects the
comment.