### PR TITLE
Update cppguide to mention revision 432

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -1733,7 +1733,9 @@ references while output arguments are pointers. Input
 parameters may be <code>const</code> pointers, but we
 never allow non-<code>const</code> reference parameters
 except when required by convention, e.g.,
-<code>swap()</code>.</p>
+<code>swap()</code>. <code>iostream</code> based types 
+may also be passed as non-<code>const</code> references.
+</p>
 
 <p>However, there are some instances where using
 <code>const T*</code> is preferable to <code>const


### PR DESCRIPTION
Revision 432: Allow non-const reference parameters for iostream based types.

cpplint.py was updated to allow this in [this commit](https://github.com/google/styleguide/commit/01e47236c846571b82a0136f79288a0b07916097) however the style guide text wasn't updated.