### PR TITLE
Fixed "full hairy example" of formatting control string in Common Lisp style guide

### DIFF
--- a/lispguide.xml
+++ b/lispguide.xml
@@ -3256,7 +3256,7 @@ Robert Brown
           as the number to choose a clause.
           The same as no parameters in all other ways.
           Here's the full hairy example:
-          <code>"Items:~#[ none~; ~S~; ~S and ~S~:;~@{~#[~; and~] ~S~^ ,~}~]."</code>
+          <code>"Items: ~#[ none~; ~S~; ~S and ~S~:;~@{~S~^~#[~; and ~:;, ~]~}~]."</code>
         </dd>
       </dl>
     </BODY>


### PR DESCRIPTION
Example produced wrong results:
```
CL-USER> (format nil "Items:~#[ none~; ~S~; ~S and ~S~:;~@{~#[~; and~] ~S~^ ,~}~]." :foo :bar :baz :kadabr)
"Items: :FOO , :BAR , :BAZ , and :KADABR."
```

With this fix, it uses commas correctly:

```
CL-USER> (format nil "Items: ~#[ none~; ~S~; ~S and ~S~:;~@{~S~^~#[~; and ~:;, ~]~}~]." :foo :bar :baz :kadabr)
"Items: :FOO, :BAR, :BAZ and :KADABR."
```