### PR TITLE
[objc] Make objcguide.xml link to objcguide.md 🔄

### DIFF
--- a/objcguide.xml
+++ b/objcguide.xml
@@ -3,6 +3,6 @@
 <GUIDE title="Google Objective-C Style Guide">
   <p>
     The style guide has moved to
-    <a href="objcguide.md">objcguide.md</a>
+    <a href="https://github.com/google/styleguide/blob/gh-pages/objcguide.md">objcguide.md</a>
   </p>
 </GUIDE>

--- a/objcguide.xml
+++ b/objcguide.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="styleguide.xsl"?>
+<GUIDE title="Google Objective-C Style Guide">
+  <p>
+    The style guide has moved to
+    <a href="objcguide.md">objcguide.md</a>
+  </p>
+</GUIDE>


### PR DESCRIPTION
There are links out in the wild to the old XML style guide. An XML file that links to the new style guide location ensures that those links are not completely broken.