### PR TITLE
Ignore file header formatting on Java

### DIFF
--- a/eclipse-java-google-style.xml
+++ b/eclipse-java-google-style.xml
@@ -288,7 +288,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>


### PR DESCRIPTION
I want to ignore file header formatting on Java, because I add file header using build tool like the [formatter-maven-plugin](https://github.com/revelc/formatter-maven-plugin). (= I want to keep original format)
I read the "3.1 License or copyright information, if present](https://google.github.io/styleguide/javaguide.html#s3.1-copyright-statement)" section of "Google Java Style Guide", it does not mention formatting of the file header.

What do you think?
