### PR TITLE
Allow break line between import groups

### DIFF
--- a/eclipse-java-google-style.xml
+++ b/eclipse-java-google-style.xml
@@ -241,7 +241,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant.count_dependent" value="16|-1|16"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>


### PR DESCRIPTION
Google Java Style Guide says as folows in "[3.3 Import statements](http://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing)":

```
Imports are ordered as follows:

1. All static imports in a single block.
2. All non-static imports in a single block.

If there are both static and non-static imports, a single blank line separates the two blocks. There are no other blank lines between import statements.
```

But the current `eclipse-java-google-style.xml` not allow adding the break line between import groups.


