### PR TITLE
Cpplint: Specify Python version

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
When executed with Python 3, it returns with error code `1`.