### PR TITLE
Update intellij-java-google-style.xml

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -110,6 +110,7 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
+    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />


### PR DESCRIPTION
Default intellij make simple line comment on first position like this:
|//   some code
Accoding google styleguide same ident level must be using for comments too (https://google.github.io/styleguide/javaguide.html#s4.2-block-indentation)
This option disable  commenting on first column, so comment will look like:
|    //some code