### PR TITLE
cpplint: Fix --root for non-subdirectories

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1777,6 +1777,8 @@ def GetHeaderGuardCPPVariable(filename):
   fileinfo = FileInfo(filename)
   file_path_from_root = fileinfo.RepositoryName()
   if _root:
+    file_path_from_root = fileinfo.FullName()
+
     suffix = os.sep
     # On Windows using directory separator will leave us with
     # "bogus escape error" unless we properly escape regex.


### PR DESCRIPTION
Using cpplint.py --root with directories at a more outer level
than the repository would not work.

For example given

  $> cpplint.py  --root=/a/b  /a/b/c/.git/filename.cpp

Trying to use --root=/a/b would get ignored, and it would
ask for a headerguard of FILENAME_H_ instead of C_FILENAME_H_
as expected.

Now --root will always use the "full name" and then strip off --root
prefix, giving us the desired effect.