### PR TITLE
Revert "cpplint: Fix --root for non-subdirectories"

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1777,8 +1777,6 @@ def GetHeaderGuardCPPVariable(filename):
   fileinfo = FileInfo(filename)
   file_path_from_root = fileinfo.RepositoryName()
   if _root:
-    file_path_from_root = fileinfo.FullName()
-
     suffix = os.sep
     # On Windows using directory separator will leave us with
     # "bogus escape error" unless we properly escape regex.


### PR DESCRIPTION
Reverts google/styleguide#289