### PR TITLE
CPPLINT.cfg root=setting is now relative to CFG file.

### DIFF
--- a/cpplint/nested/cpplint_test_header.h
+++ b/cpplint/nested/cpplint_test_header.h
@@ -1,0 +1,1 @@
+// A test header for cpplint_unittest.py.


### PR DESCRIPTION
Also further improve the documentation and testing around ```--root```.

Previously the `root=setting` in the CFG file was treated identically
to passing ```--root=setting``` on the command line, which seems undesirable
since it depends on were CPPLINT.cfg was invoked from (for relative
paths).

Judging on settings such as ```'exclude_files'``` it seems within the spirit
to make the settings 'current working directory' contextual to the
same directory that CPPLINT.cfg is in.

This also makes execution consistent (picking up the "correct" settings)
regardless of the CWD when executing cpplint.py.

Example:

```
  echo 'root=..' >> /a/b/c/CPPLINT.cfg
  cd /
  cpplint.py /a/b/c/source_file.h
  # expects header guard of C_SOURCE_FILE_H_
```

However the old behavior would use '/../' = '/'
and incorrectly think the root was ``` 'A_B_C_SOURCE_FILE_H_'```.