### PR TITLE
cpplint: Fix unittests when the styleguide directory is named otherwise

### DIFF
--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -4280,12 +4280,14 @@ class CpplintTest(CpplintTestBase):
     # (note that CPPLINT.cfg root=setting is always made absolute)
     this_files_path = os.path.dirname(os.path.abspath(__file__))
     (styleguide_path, this_files_dir) = os.path.split(this_files_path)
-    (styleguide_parent_path, _) = os.path.split(styleguide_path)
+    (styleguide_parent_path, styleguide_dir_name) = os.path.split(styleguide_path)
     # parent dir of styleguide
     cpplint._root = styleguide_parent_path
     self.assertIsNotNone(styleguide_parent_path)
+    # do not hardcode the 'styleguide' repository name, it could be anything.
+    expected_prefix = re.sub(r'[^a-zA-Z0-9]', '_', styleguide_dir_name).upper() + '_'
     # do not have 'styleguide' repo in '/'
-    self.assertEquals('STYLEGUIDE_CPPLINT_CPPLINT_TEST_HEADER_H_',
+    self.assertEquals('%sCPPLINT_CPPLINT_TEST_HEADER_H_' %(expected_prefix),
                       cpplint.GetHeaderGuardCPPVariable(file_path))
 
     # To run the 'relative path' tests, we must be in the directory of this test file.
@@ -4302,7 +4304,7 @@ class CpplintTest(CpplintTestBase):
     styleguide_rel_path = os.path.relpath(styleguide_parent_path,
                                           this_files_path) # '../..'
     cpplint._root = styleguide_rel_path
-    self.assertEquals('STYLEGUIDE_CPPLINT_CPPLINT_TEST_HEADER_H_',
+    self.assertEquals('%sCPPLINT_CPPLINT_TEST_HEADER_H_' %(expected_prefix),
                       cpplint.GetHeaderGuardCPPVariable(file_path))
 
     cpplint._root = None


### PR DESCRIPTION
Don't hardcode the 'styleguide' directory in unit tests, instead
get it from the ```../..``` basename.

(It was failing when the repository directory was named differently, e.g. 'google-styleguide' directory, like we have in AOSP)