### PR TITLE
(Eclipse formatter) Do not format html in Javadoc

### DIFF
--- a/eclipse-java-google-style.xml
+++ b/eclipse-java-google-style.xml
@@ -268,7 +268,7 @@
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="1585"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>


### PR DESCRIPTION
Make eclipse formatter comply with section '7.1.2 Paragraphs' by keeping
the first word in the paragraph immediately following the paragraph tag.

Normally, Eclipse would insert a newline in the javadoc, and begin the
paragraph on the next line. That's because surrounding whitespace should
not matter for HTML block level elements like the paragraph tag, and
this improves readability of the Javadoc source. However, the Google
StyleGuide for Java forbids this extra newline in section 7.1.2. The
only way to have Eclipse respect this is by disabling html formatting
entirely.