### PR TITLE
Intellij INDENT_ON_CONTINUATION needs to be true

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -32,6 +32,7 @@
   <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
   <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
   <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+  <option name="JD_INDENT_ON_CONTINUATION" value="true" />
   <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
   <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
   <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />


### PR DESCRIPTION
As stated in the Style guide at paragraph `7.1.3 Block tags`:

> When a block tag doesn't fit on a single line, continuation lines are indented four (or more) spaces from the position of the @

Intellij's formatter needs to have "JD_INDENT_ON_CONTINUATION" flag set to true.