### PR TITLE
Nit: s/template string/template literal/g

### DIFF
--- a/jsguide.html
+++ b/jsguide.html
@@ -1478,13 +1478,13 @@ string to avoid having to escape the quote.</p>
 
 <p>Ordinary string literals may not span multiple lines.</p>
 
-<h4 id="features-strings-template-strings">5.6.2 Template strings</h4>
+<h4 id="features-strings-template-strings">5.6.2 Template literals</h4>
 
-<p>Use template strings (delimited with <code>`</code>) over complex string
+<p>Use template literals (delimited with <code>`</code>) over complex string
 concatenation, particularly if multiple string literals are involved. Template
-strings may span multiple lines.</p>
+literals may span multiple lines.</p>
 
-<p>If a template string spans multiple lines, it does not need to follow the
+<p>If a template literal spans multiple lines, it does not need to follow the
 indentation of the enclosing block, though it may if the added whitespace does
 not matter.</p>
 


### PR DESCRIPTION
The correct terminology is “template literal”. There is no such thing as a “template string”.

This patch leaves the `id` attribute value intact so that old links to this section don’t break.