### PR TITLE
Fix: Improve formatting of whitespace

### DIFF
--- a/pyguide.html
+++ b/pyguide.html
@@ -1394,8 +1394,8 @@ No:  <span class="external"></span>def foo(a, b=FLAGS.my_thing):  # sys.argv has
        <span class="external"></span># No hanging indent in a dictionary
        <span class="external"></span>foo = {
        <span class="external"></span>    long_dictionary_key:
-           <span class="external">    </span>long_dictionary_value,
-           <span class="external">    </span>...
+       <span class="external"></span>    long_dictionary_value,
+       <span class="external"></span>    ...
        <span class="external"></span>}</PRE></DIV>
       </DIV></DIV>
     </DIV>


### PR DESCRIPTION
The issue is that the "Yes" section and "No" section show identical indentation for the last case (hanging indent in a dictionary)

https://google.github.io/styleguide/pyguide.html?showone=Indentation#Indentation