### PR TITLE
Fixed --root option under Windows

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1860,7 +1860,7 @@ def GetHeaderGuardCPPVariable(filename):
 
     #   --root=.. , will prepend the outer directory to the header guard
     full_path = fileinfo.FullName()
-    root_abspath = os.path.abspath(_root)
+    root_abspath = os.path.abspath(_root).replace('\\', '/')
 
     maybe_path = StripListPrefix(PathSplitToList(full_path),
                                  PathSplitToList(root_abspath))


### PR DESCRIPTION
The --root option and CPPLINT.cfg "root=" setting does not work under Windows,
at least not for relative paths,
due to the way the absolute path for the root is obtained.