### PR TITLE
Link to the maintained pyguide.md, not old html.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following Google style guides live outside of this project:
 [cpp]: https://google.github.io/styleguide/cppguide.html
 [objc]: objcguide.md
 [java]: https://google.github.io/styleguide/javaguide.html
-[py]: https://google.github.io/styleguide/pyguide.html
+[py]: https://github.com/google/styleguide/blob/gh-pages/pyguide.md
 [r]: https://google.github.io/styleguide/Rguide.xml
 [sh]: https://google.github.io/styleguide/shell.xml
 [htmlcss]: https://google.github.io/styleguide/htmlcssguide.html

--- a/pyguide.html
+++ b/pyguide.html
@@ -1,6 +1,6 @@
 <HTML xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcq="http://purl.org/dc/qualifiers/1.0/" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:fn="http://www.w3.org/2005/xpath-functions">
 <HEAD>
-<TITLE>Google Python Style Guide</TITLE>
+<TITLE>[Deprecated] Google Python Style Guide</TITLE>
 <META http-equiv="Content-Type" content="text/html; charset=utf-8">
 <LINK HREF="https://www.google.com/favicon.ico" type="image/x-icon" rel="shortcut icon">
 <LINK HREF="styleguide.css" type="text/css" rel="stylesheet">
@@ -133,20 +133,15 @@
               </SCRIPT>
 </HEAD>
 <BODY>
-<H1>Google Python Style Guide</H1>
+<H1>Deprecated Google Python Style Guide</H1>
   <p align="right">
 
     Revision 2.59
+    <b>This is an obsolete unmaintained copy of the style guide.
+      <a href="https://github.com/google/styleguide/blob/gh-pages/pyguide.md">Please use pyguide.md instead</a>.
+    </b>
   </p>
   
-  <address>
-    Amit Patel<br>
-    Antoine Picard<br>
-    Eugene Jhong<br>
-    Jeremy Hylton<br>
-    Matt Smart<br>
-    Mike Shields<br>
-  </address>
   <DIV style="margin-left: 50%; font-size: 75%;">
 <P>
         Each style point has a summary for which additional information is available


### PR DESCRIPTION
pyguide.html is unmaintained and has been for ~5 years.  pyguide.md
is reasonably up to date and we have the ability to keep it up to
date from our internal guide.  Link to that instead.

I'd like to delete the old pyguide.html but a lot of things still
point directly at it so they at least have somewhere to land for
the time being.