### PR TITLE
Fix rendering for table in pyguide

### DIFF
--- a/pyguide.md
+++ b/pyguide.md
@@ -2064,7 +2064,7 @@ containing `exec "$0.py" "$@"`.
     <td></td>
   </tr>
 
-    <tr>
+  <tr>
     <td>Functions</td>
     <td><code>lower_with_under()</code></td>
     <td><code>_lower_with_under()</code></td>
@@ -2088,7 +2088,7 @@ containing `exec "$0.py" "$@"`.
     <td><code>_lower_with_under</code> (protected)</td>
   </tr>
 
-    <tr>
+  <tr>
     <td>Method Names</td>
     <td><code>lower_with_under()</code></td>
     <td><code>_lower_with_under()</code> (protected)</td>


### PR DESCRIPTION
There are missing spaces for the syntax of the table (matters in Github Markdown) that causes rendering error.

![image](https://user-images.githubusercontent.com/7029882/41504616-dd2147e6-7226-11e8-95db-e35c437489aa.png)
