### PR TITLE
Add structured binding support from c++17 to cpplint

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -3283,8 +3283,8 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
   line = clean_lines.elided[linenum]
 
   # You shouldn't have spaces before your brackets, except maybe after
-  # 'delete []' or 'return []() {};'
-  if Search(r'\w\s+\[', line) and not Search(r'(?:delete|return)\s+\[', line):
+  # 'delete []' or 'return []() {};' or 'auto [x, y] = pair;'
+  if Search(r'\w\s+\[', line) and not Search(r'(?:delete|return|auto)\s+\[', line):
     error(filename, linenum, 'whitespace/braces', 5,
           'Extra space before [')
 
@@ -4301,7 +4301,7 @@ def GetLineWidth(line):
           is_low_surrogate = 0xDC00 <= ord(uc) <= 0xDFFF
           if not is_wide_build and is_low_surrogate:
             width -= 1
-          
+
         width += 1
     return width
   else:

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -2567,6 +2567,10 @@ class CpplintTest(CpplintTestBase):
     # Avoid false positives with operator[]
     self.TestLint('table_to_children[&*table].push_back(dependent);', '')
 
+  def testStructuredBinding(self):
+    self.TestLint('auto [a, b] = pair;', '')
+    self.TestLint('auto& [a, b] = pair;', '')
+
   def testBraceInitializerList(self):
     self.TestLint('MyStruct p = {1, 2};', '')
     self.TestLint('MyStruct p{1, 2};', '')
@@ -3853,13 +3857,13 @@ class CpplintTest(CpplintTestBase):
       self.assertEqual(['foo.h'],
                        cpplint.ParseArguments(['--extensions=hpp,cpp,cpp', 'foo.h']))
       self.assertEqual(set(['hpp', 'cpp']), cpplint._valid_extensions)
-      
+
       self.assertEqual(set(['h']), cpplint._hpp_headers)  # Default value
       self.assertEqual(['foo.h'],
                        cpplint.ParseArguments(['--extensions=cpp,cpp', '--headers=hpp,h', 'foo.h']))
       self.assertEqual(set(['hpp', 'h']), cpplint._hpp_headers)
       self.assertEqual(set(['hpp', 'h', 'cpp']), cpplint._valid_extensions)
-      
+
     finally:
       cpplint._USAGE = old_usage
       cpplint._ERROR_CATEGORIES = old_error_categories


### PR DESCRIPTION
http://en.cppreference.com/w/cpp/language/structured_binding
Allow code like `auto [a, b] = pair;`