### PR TITLE
Add horizontal TOC back into style guide

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -10,6 +10,7 @@
 <body onload="initStyleGuide();">
 <div id="content">
 <h1>Google C++ Style Guide</h1>
+<div class="horizontal_toc" id="tocDiv"></div>
 <div class="main_body">
 
 <h2 class="ignoreLink" id="Background">Background</h2>


### PR DESCRIPTION
We are transitioning the C++ styleguide to markdown. For the time being, however, this TOC Should remain.