### PR TITLE
Change the URL in the example of data.previousLink from /next to /previous

### DIFF
--- a/jsoncstyleguide.xml
+++ b/jsoncstyleguide.xml
@@ -840,7 +840,7 @@ Property Value Type: object / string<br />Parent: <code>data</code>
 {
   "data": {
     "previous": { },
-    "previousLink": "https://www.google.com/feeds/album/1234/next"
+    "previousLink": "https://www.google.com/feeds/album/1234/previous"
   }
 }
 


### PR DESCRIPTION
I think /previous or /prev is more appropriate for previousLink.