### PR TITLE
add wrap_long_lines in intellij-java-google-style.xml 

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -133,6 +133,7 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="WRAP_LONG_LINES" value="true" />
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
       <option name="CONTINUATION_INDENT_SIZE" value="4" />


### PR DESCRIPTION
if one line code is too long, it is bad to watch code in screen, 

```
<option name="RIGHT_MARGIN" value="140" />
```

limit the one line code length, but we can not reformat it with ‘reformat code’ keymap when our code is longer than limit length.

with this set, we can reformat it 

```
<option name="WRAP_LONG_LINES" value="true" />
```