### PR TITLE
UTF-8 no BOM

### DIFF
--- a/javaguide.html
+++ b/javaguide.html
@@ -62,9 +62,9 @@ code. Optional formatting choices made in examples should not be enforced as rul
 (of which there is <a href="#s3.4.1-one-top-level-class">exactly one</a>), plus the
 <code>.java</code> extension.</p>
 
-<h3 id="s2.2-file-encoding">2.2 File encoding: UTF-8 no BOM</h3>
+<h3 id="s2.2-file-encoding">2.2 File encoding: UTF-8</h3>
 
-<p>Source files are encoded in <strong>UTF-8</strong>.</p>
+<p>Source files are encoded in <strong>UTF-8</strong> no BOM.</p>
 
 <h3 id="s2.3-special-characters">2.3 Special characters</h3>
 

--- a/javaguide.html
+++ b/javaguide.html
@@ -62,7 +62,7 @@ code. Optional formatting choices made in examples should not be enforced as rul
 (of which there is <a href="#s3.4.1-one-top-level-class">exactly one</a>), plus the
 <code>.java</code> extension.</p>
 
-<h3 id="s2.2-file-encoding">2.2 File encoding: UTF-8</h3>
+<h3 id="s2.2-file-encoding">2.2 File encoding: UTF-8 no BOM</h3>
 
 <p>Source files are encoded in <strong>UTF-8</strong>.</p>
 


### PR DESCRIPTION
Specify that no byte order mark should be used (when applicable) for source files.