### PR TITLE
shell: fix ShellCheck error SC2145 in err function

### DIFF
--- a/shell.xml
+++ b/shell.xml
@@ -145,7 +145,7 @@ Revision 1.26
         information is recommended.
         <CODE_SNIPPET>
           err() {
-            echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" &gt;&amp;2
+            echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]:" "$@" &gt;&amp;2
           }
 
           if ! do_something; then


### PR DESCRIPTION
For more information:
  https://www.shellcheck.net/wiki/SC2145 -- Argument mixes string and array. ...