### PR TITLE
update jQuery version in example

### DIFF
--- a/htmlcssguide.html
+++ b/htmlcssguide.html
@@ -32,14 +32,14 @@ files, style sheets, and scripts, unless the respective files are not available
 over HTTPS.</p>
 
 <pre><code class="language-html prettyprint badcode">&lt;!-- Not recommended: omits the protocol --&gt;
-&lt;script src="//ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"&gt;&lt;/script&gt;
+&lt;script src="//ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"&gt;&lt;/script&gt;
 
 &lt;!-- Not recommended: uses HTTP --&gt;
-&lt;script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"&gt;&lt;/script&gt;
+&lt;script src="http://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"&gt;&lt;/script&gt;
 </code></pre>
 
 <pre><code class="language-html prettyprint">&lt;!-- Recommended --&gt;
-&lt;script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"&gt;&lt;/script&gt;
+&lt;script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"&gt;&lt;/script&gt;
 </code></pre>
 
 <pre><code class="language-css prettyprint badcode">/* Not recommended: omits the protocol */


### PR DESCRIPTION
I know it's only an example, but best to have the most recent version here which doesn't have a known security vulnerability.

REF:
- https://snyk.io/vuln/npm:jquery
- https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/