### PR TITLE
Setting the 'New line after (' property to correctly match the code styleguide

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -118,6 +118,7 @@
     <option name="ALIGN_MULTILINE_FOR" value="false" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
     <option name="EXTENDS_LIST_WRAP" value="1" />
     <option name="THROWS_KEYWORD_WRAP" value="1" />
     <option name="METHOD_CALL_CHAIN_WRAP" value="1" />


### PR DESCRIPTION
This PR fixes the issue of the property 'New line after (' in the 'Method declaration parameters' section for Java not being set to true when importing the `intellij-java-google-style.xml`. See screenshot below.

![Screenshot 2019-09-04 at 07 52 05](https://user-images.githubusercontent.com/1135081/64229170-53320680-cee9-11e9-8b03-b8083c1c4dfe.png)

When the property isn't set the code is formatted in a way that doesn't pass the formatting check by `fmt-maven-plugin`.

Please also be aware that there seems to be a bug in IDEA currently which doesn't apply this property correctly if its imported with the same code style schema name multiple times so please use a new name when testing. For some reason IDEA keeps the latest saved state of the property in that code style schema.