### PR TITLE
ignore alt_tokens when checking fncall spacing

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -2992,6 +2992,8 @@ def CheckSpacingForFunctionCall(filename, clean_lines, linenum, error):
         not Search(r'_{0,2}asm_{0,2}\s+_{0,2}volatile_{0,2}\s+\(', fncall) and
         not Search(r'#\s*define|typedef|using\s+\w+\s*=', fncall) and
         not Search(r'\w\s+\((\w+::)*\*\w+\)\(', fncall) and
+        not Search(r'\b(' + '|'.join(_ALT_TOKEN_REPLACEMENT.keys()) + r')\b\s+\(',
+                   fncall) and
         not Search(r'\bcase\s+\(', fncall)):
       # TODO(unknown): Space after an operator function seem to be a common
       # error, silence those for now by restricting them to highest verbosity.


### PR DESCRIPTION
When `readability/alt_tokens` is disabled they can be parsed as a function name:

```c++
1 and (1 + 1)
     ^ spurious 'Extra space before ( in function call'
```