### PR TITLE
Add support for c++17 tuple destructuring

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -3283,8 +3283,8 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
   line = clean_lines.elided[linenum]
 
   # You shouldn't have spaces before your brackets, except maybe after
-  # 'delete []' or 'return []() {};'
-  if Search(r'\w\s+\[', line) and not Search(r'(?:delete|return)\s+\[', line):
+  # 'delete []', 'return []() {};', or 'auto [abc, ...] = ...;'.
+  if Search(r'\w\s+\[', line) and not Search(r'(?:auto&?|delete|return)\s+\[', line):
     error(filename, linenum, 'whitespace/braces', 5,
           'Extra space before [')
 


### PR DESCRIPTION
C++17 adds support for tuple destructuring. This allow one to write
code such as:

```
std::pair<int, int> span = getSpan();
auto [start, end] = span;

// Use start as span.first and end as span.second
```

This makes cpplint recognize and allow a space before the '[' in this
situation.

This is a purposeful divergence from the internal version where the
entire whitespace/braces category was removed. It was decided to leave
the checks in since this is sometimes used without other formatting
tools.

Test: manual