### PR TITLE
C++ Style Guide: Remove redundant comment guideline

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -4403,9 +4403,6 @@ one may be you!</p>
 
 <h3 id="Comment_Style">Comment Style</h3>
 
-<p>Use either the <code>//</code> or <code>/* */</code>
-syntax, as long as you are consistent.</p>
-
 <p>You can use either the <code>//</code> or the <code>/*
 */</code> syntax; however, <code>//</code> is
 <em>much</em> more common. Be consistent with how you


### PR DESCRIPTION
Remove a guideline which is reiterated (with more specificity) in the following guideline.