### PR TITLE
Fix argument name

### DIFF
--- a/shellguide.md
+++ b/shellguide.md
@@ -811,7 +811,7 @@ mybinary ${flags}
 # work correctly if the command output contains special
 # characters.
 declare -a files=($(ls /directory))
-mybinary $(get_arguments)
+mybinary $(files)
 ```
 
 <a id="s6.7.1-arrays-pros"></a>


### PR DESCRIPTION
The above examples use the same variable as an input to `mybinary`; it doesn't make sense/seems like an oversight to pass an undeclared `get_arguments` in this case.