### PR TITLE
shell guide: remove event designator "!?"

### DIFF
--- a/shellguide.md
+++ b/shellguide.md
@@ -936,7 +936,7 @@ statement, and otherwise be wary of its expression evaluating to zero
 ```shell
 # Simple calculation used as text - note the use of $(( … )) within
 # a string.
-echo "$(( 2 + 2 )) is 4!?"
+echo "$(( 2 + 2 )) is 4"
 
 # When performing arithmetic comparisons for testing
 if (( a < b )); then


### PR DESCRIPTION
The "!?" in the example code will be replaced by the most recent command. It is not a desired behavior.