### PR TITLE
[C++ styleguide] Restore table of contents

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -10,6 +10,8 @@
 <body onload="initStyleGuide();">
 <div id="content">
 <h1>Google C++ Style Guide</h1>
+<div class="horizontal_toc" id="tocDiv"></div>
+
 <h2 id="Background" class="ignoreLink">Background</h2>
 
 <p>C++ is one of the main development languages  used by


### PR DESCRIPTION
This was mistakenly dropped when updating the styleguide from the
internal C++ styleguide.