### PR TITLE
Render TOC properly on Github Pages

### DIFF
--- a/pyguide.md
+++ b/pyguide.md
@@ -6,9 +6,7 @@ See README.md for details.
 
 # Google Python Style Guide
 
-<!-- https://github.com/google/styleguide/issues/566: Can this render properly on Github Pages? -->
-
-<details>
+<details markdown="1">
   <summary>Table of Contents</summary>
 
 -   [1 Background](#s1-background)


### PR DESCRIPTION
Fixes #566 

## Before

<img width="1087" alt="Screen Shot 2020-07-22 at 10 09 30 PM" src="https://user-images.githubusercontent.com/11613096/88187203-d0cd4500-cc68-11ea-9c28-2d5e7004800b.png">

## After

<img width="1059" alt="Screen Shot 2020-07-22 at 10 08 36 PM" src="https://user-images.githubusercontent.com/11613096/88187219-d88ce980-cc68-11ea-9c91-4e1933761782.png">
