### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+lispguide.xml @sfreilich


### PR DESCRIPTION
Since this repository contains style guides managed by different owners/teams, it might be convenient to have a way to allow maintainers to get notified about PRs for specific files. GitHub's code owners feature provides a way to do that:
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

Adding myself to this for the Lisp Style Guide.