### PR TITLE
Fix spelling mistake - unncessary

### DIFF
--- a/jsguide.html
+++ b/jsguide.html
@@ -92,7 +92,7 @@ characters are used, an explanatory comment can be very helpful.</p>
 <pre><code class="language-js prettyprint">/* Best: perfectly clear even without a comment. */
 const units = '&#956;s';
 
-/* Allowed: but unncessary as &#956; is a printable character. */
+/* Allowed: but unnecessary as &#956; is a printable character. */
 const units = '\u03bcs'; // '&#956;s'
 
 /* Good: use escapes for non-printable characters with a comment for clarity. */


### PR DESCRIPTION
Fix spelling mistake

from `unncessary`
to `unnecessary`
