### PR TITLE
Update out-of-date JSDoc link

### DIFF
--- a/jsguide.html
+++ b/jsguide.html
@@ -2459,7 +2459,7 @@ character of:
 
 <h2 id="jsdoc">7 JSDoc</h2>
 
-<p><a href="https://developers.google.com/closure/compiler/docs/js-for-compiler">JSDoc</a> is used on all classes, fields, and methods.</p>
+<p><a href="https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler">JSDoc</a> is used on all classes, fields, and methods.</p>
 
 <h3 id="jsdoc-general-form">7.1 General form</h3>
 


### PR DESCRIPTION
JSDoc link is outdated:
- Current/ Out of date: https://developers.google.com/closure/compiler/docs/js-for-compiler
- Correct one: https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler