### PR TITLE
Add yes/no labels to pyguide snippets

### DIFF
--- a/pyguide.md
+++ b/pyguide.md
@@ -949,6 +949,7 @@ true-expression, if-expression, else-expression. Use a complete if statement
 when things get more complicated.
 
 ```python
+Yes:
 one_line = 'yes' if predicate(value) else 'no'
 slightly_split = ('yes' if predicate(value)
                   else 'no, nein, nyet')
@@ -959,6 +960,7 @@ the_longest_ternary_style_that_can_be_done = (
 ```
 
 ```python
+No:
 bad_line_breaking = ('yes' if predicate(value) else
                      'no')
 portion_too_long = ('yes'


### PR DESCRIPTION
Most guidelines in pyguide.md are demonstrated by showing a yes and
no code example, which are each labeled as such.

This commit adds missing yes/no labels to the example pair about
Conditional Expressions.

Signed-off-by: Lukas Puehringer <lukas.puehringer@nyu.edu>