### PR TITLE
Java: Recommend using inline `{@return }` for Java >= 16

### DIFF
--- a/javaguide.html
+++ b/javaguide.html
@@ -83,7 +83,7 @@ anywhere in a source file. This implies that:</p>
 <h4 id="s2.3.2-special-escape-sequences">2.3.2 Special escape sequences</h4>
 
 <p>For any character that has a
-<a href="http://docs.oracle.com/javase/tutorial/java/data/characters.html">
+<a href="https://docs.oracle.com/javase/tutorial/java/data/characters.html">
   special escape sequence</a>
 (<code class="prettyprint lang-java">\b</code>,
 <code class="prettyprint lang-java">\t</code>,
@@ -262,7 +262,7 @@ body is empty or contains only a single statement.</p>
 <h4 id="s4.1.2-blocks-k-r-style">4.1.2 Nonempty blocks: K &amp; R style</h4>
 
 <p>Braces follow the Kernighan and Ritchie style
-("<a href="http://www.codinghorror.com/blog/2012/07/new-programming-jargon.html">Egyptian brackets</a>")
+("<a href="https://blog.codinghorror.com/new-programming-jargon/">Egyptian brackets</a>")
 for <em>nonempty</em> blocks and block-like constructs:</p>
 
 <ul>
@@ -1073,7 +1073,7 @@ lang-java">Object.finalize</code>.</p>
 <p class="tip"><strong>Tip:</strong> Don't do it. If you absolutely must, first read and understand
 
 
-  <a href="http://books.google.com/books?isbn=8131726592"><em>Effective Java</em> Item 7,</a>
+  <a href="https://books.google.com/books?isbn=8131726592"><em>Effective Java</em> Item 7,</a>
 
 "Avoid Finalizers," very carefully, and <em>then</em> don't do it.</p>
 

--- a/javaguide.html
+++ b/javaguide.html
@@ -1137,6 +1137,12 @@ punctuated as if it were a complete sentence.</p>
 <p class="tip"><strong>Tip:</strong> A common mistake is to write simple Javadoc in the form
 <code class="badcode">/** @return the customer ID */</code>. This is incorrect, and should be
 changed to <code class="prettyprint lang-java">/** Returns the customer ID. */</code>.</p>
+<p class="tip"><strong>Tip:</strong> When targeting Java 16 or newer, use the
+<a href="https://docs.oracle.com/en/java/javase/16/docs/specs/javadoc/doc-comment-spec.html#return">
+inline <code>{@return <var>description</var>}</code> tag</a> to not repeat yourself. For example
+<code class="prettyprint lang-java">/** {@return the name} {@code null} if unknown. */</code>
+will generate the description "Returns the name. <code>null</code> if unknown." and additionally
+uses "the name" as description for the return value.</p>
 
 <a name="s7.3.3-javadoc-optional"></a> 
 <h3 id="s7.3-javadoc-where-required">7.3 Where Javadoc is used</h3>


### PR DESCRIPTION
[JDK-8075778](https://bugs.openjdk.java.net/browse/JDK-8075778) (note that the issue description does not match the final implementation) introduced an [inline `{@return }` tag](https://docs.oracle.com/en/java/javase/16/docs/specs/javadoc/doc-comment-spec.html#return) for Java 16. This tag should be preferred to avoid repetition, e.g.:
```java
/**
 * Returns the name.
 * @return the name
 */
```
Instead:
```java
/**
 * {@return the name}
 */
```

The current recommendation of the style guide to omit the `@return` tag would yield a javadoc warning and would not create a description for the return type.
