### PR TITLE
Revert "cppguide: remove space before comma"

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -4662,7 +4662,8 @@ one of the following remedies:</p>
   values self-describing.</li>
 
   <li>For functions that have several configuration options, consider
-  defining a single class or struct to hold all the options,
+  defining a single class or struct to hold all the options
+  ,
   and pass an instance of that.
   This approach has several advantages. Options are referenced by name
   at the call site, which clarifies their meaning. It also reduces


### PR DESCRIPTION
These style guides are copies of Google's internal style guides to
assist developers working on Google owned and originated open source
projects. Changes should be made to the internal style guide first and
only then copied here.

Unsolicited pull requests will not be merged and are usually closed
without comment. If a PR points out a simple mistake — a typo, a broken
link, etc. — then the correction can be made internally and copied here
through the usual process.

Substantive changes to the style rules and suggested new rules should
not be submitted as a PR in this repository. Material changes must be
proposed, discussed, and approved on the internal forums first.
