### PR TITLE
Update jsguide.html-issue #656

### DIFF
--- a/jsguide.html
+++ b/jsguide.html
@@ -186,7 +186,7 @@ namespace, this name <strong>must not</strong> be a child or parent of any other
 <code>goog.module('parent.child');</code> cannot both exist safely, nor can
 <code>goog.module('parent');</code> and <code>goog.module('parent.child.grandchild');</code>).</p>
 
-<h3 id="file-goog-module-exports">3.3.3 <code>goog.module</code> Exports</h3>
+<h4 id="file-goog-module-exports">3.3.3 <code>goog.module</code> Exports</h4>
 
 <p>Classes, enums, functions, constants, and other symbols are exported using the
 <code>exports</code> object. Exported symbols may be defined directly on the <code>exports</code>


### PR DESCRIPTION
Issue #656 -In  javascript guide , 3.3.3 is showing up in the table of contents as it is inside the <h3>. So updated it with h4 tag

These style guides are copies of Google's internal style guides to
assist developers working on Google owned and originated open source
projects. Changes should be made to the internal style guide first and
only then copied here.

Unsolicited pull requests will not be merged and are usually closed
without comment. If a PR points out a simple mistake — a typo, a broken
link, etc. — then the correction can be made internally and copied here
through the usual process.

Substantive changes to the style rules and suggested new rules should
not be submitted as a PR in this repository. Material changes must be
proposed, discussed, and approved on the internal forums first.
