### PR TITLE
google-c-style.el: Fix byte compilation warning

### DIFF
--- a/google-c-style.el
+++ b/google-c-style.el
@@ -30,6 +30,7 @@
 ;; For some reason 1) c-backward-syntactic-ws is a macro and 2)  under Emacs 22
 ;; bytecode cannot call (unexpanded) macros at run time:
 (eval-when-compile (require 'cc-defs))
+(require 'cc-mode)
 
 ;; Wrapper function needed for Emacs 21 and XEmacs (Emacs 22 offers the more
 ;; elegant solution of composing a list of lineup functions or quantities with


### PR DESCRIPTION
The command ‘google-make-newline-indent’ uses ‘c-mode-base-map’, which is
defined in ‘cc-mode’, so we should ‘require’ that library.