### PR TITLE
Typo fix: change 7.3.4 to 7.3.3 in javaguide.html

### DIFF
--- a/javaguide.html
+++ b/javaguide.html
@@ -1189,7 +1189,6 @@ punctuated as if it were a complete sentence.</p>
 incorrect, and should be changed to
 <code class="prettyprint lang-java">/** Returns the customer ID. */</code>.</p>
 
-<a name="s7.3.3-javadoc-optional"></a> 
 <h3 id="s7.3-javadoc-where-required">7.3 Where Javadoc is used</h3>
 
 <p>At the <em>minimum</em>, Javadoc is present for every
@@ -1198,8 +1197,8 @@ incorrect, and should be changed to
 <code class="prettyprint lang-java">protected</code> member of such a class, with a few exceptions
 noted below.</p>
 
-<p>Additional Javadoc content may also be present, as explained in Section 7.3.4,
-<a href="#s7.3.4-javadoc-non-required">Non-required Javadoc</a>.</p>
+<p>Additional Javadoc content may also be present, as explained in Section 7.3.3,
+<a href="#s7.3.3-javadoc-non-required">Non-required Javadoc</a>.</p>
 
 <h4 id="s7.3.1-javadoc-exception-self-explanatory">7.3.1 Exception: self-explanatory members</h4>
 
@@ -1222,7 +1221,7 @@ what the term "canonical name" means!</p>
 
 
 
-<h4 id="s7.3.4-javadoc-non-required">7.3.4 Non-required Javadoc</h4>
+<h4 id="s7.3.3-javadoc-non-required">7.3.3 Non-required Javadoc</h4>
 
 <p>Other classes and members have Javadoc <em>as needed or desired</em>.
 


### PR DESCRIPTION
1. There is no 7.3.3, so 7.3.4 is changed to 7.3.3. 
2. Delete useless hyperlink <a> for previous 7.3.3.

These style guides are copies of Google's internal style guides to
assist developers working on Google owned and originated open source
projects. Changes should be made to the internal style guide first and
only then copied here.

Unsolicited pull requests will not be merged and are usually closed
without comment. If a PR points out a simple mistake — a typo, a broken
link, etc. — then the correction can be made internally and copied here
through the usual process.

Substantive changes to the style rules and suggested new rules should
not be submitted as a PR in this repository. Material changes must be
proposed, discussed, and approved on the internal forums first.
