### PR TITLE
Remove irrelevant options

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -155,12 +155,6 @@ disable=abstract-method,
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]". This option is deprecated
-# and it will be removed in Pylint 2.0.
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=no
 
@@ -278,12 +272,6 @@ ignore-long-lines=(?x)(
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=yes
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=
 
 # Maximum number of lines in a module
 max-module-lines=99999


### PR DESCRIPTION
************* Module /etc/pylintrc
/etc/pylintrc:1:0: E0015: Unrecognized option found: files-output, no-space-check (unrecognized-option)

Distributor ID:	Ubuntu
Description:	Ubuntu 22.04 LTS
Release:	22.04
Codename:	jammy

pylint 2.14.0
astroid 2.11.5
Python 3.8.13 (default, Mar 28 2022, 11:38:47) 
[GCC 7.5.0]

These style guides are copies of Google's internal style guides to
assist developers working on Google owned and originated open source
projects. Changes should be made to the internal style guide first and
only then copied here.

Unsolicited pull requests will not be merged and are usually closed
without comment. If a PR points out a simple mistake — a typo, a broken
link, etc. — then the correction can be made internally and copied here
through the usual process.

Substantive changes to the style rules and suggested new rules should
not be submitted as a PR in this repository. Material changes must be
proposed, discussed, and approved on the internal forums first.
