### PR TITLE
cppguide: fix html markup & namespace

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -174,9 +174,8 @@ input.</p>
 <p>Do not use
   <a href="#Nonstandard_Extensions">non-standard extensions</a>.</p>
 
-  <div>Consider portability to other environments
-before using features from C++14 and C++17 in your project.
-</div>
+<p>Consider portability to other environments
+before using features from C++14 and C++17 in your project.</p>
 
 <h2 id="Header_Files">Header Files</h2>
 
@@ -230,15 +229,11 @@ should be
 
 <code><i>&lt;PROJECT&gt;</i>_<i>&lt;PATH&gt;</i>_<i>&lt;FILE&gt;</i>_H_</code>.</p>
 
-
-
-<div>
 <p>To guarantee uniqueness, they should
 be based on the full path in a project's source tree. For
 example, the file <code>foo/src/bar/baz.h</code> in
 project <code>foo</code> should have the following
 guard:</p>
-</div>
 
 <pre>#ifndef FOO_BAR_BAZ_H_
 #define FOO_BAR_BAZ_H_
@@ -436,14 +431,11 @@ as follows:</p>
 
   <li>A blank line</li>
 
-  <div>
   <li>Other libraries' <code>.h</code> files.</li>
 
   <li>A blank line</li>
-  </div>
 
-  <li>
-  Your project's <code>.h</code>
+  <li>Your project's <code>.h</code>
   files.</li>
 </ol>
 
@@ -1180,8 +1172,8 @@ void Func(Foo f);
 </pre>
 <pre class="badcode">Func({42, 3.14});  // Error
 </pre>
-This kind of code isn't technically an implicit conversion, but the
-language treats it as one as far as <code>explicit</code> is concerned.
+<p>This kind of code isn't technically an implicit conversion, but the
+language treats it as one as far as <code>explicit</code> is concerned.</p>
 
 <p class="pros"></p>
 <ul>
@@ -1961,15 +1953,9 @@ doubt, use overloads.</p>
 
 <h2 id="Google-Specific_Magic">Google-Specific Magic</h2>
 
-
-
-<div>
 <p>There are various tricks and utilities that
 we use to make C++ code more robust, and various ways we use
 C++ that may differ from what you see elsewhere.</p>
-</div>
-
-
 
 <h3 id="Ownership_and_Smart_Pointers">Ownership and Smart Pointers</h3>
 
@@ -2108,18 +2094,12 @@ style errors. It is not perfect, and has both false
 positives and false negatives, but it is still a valuable
 tool. </p>
 
-
-
-<div>
 <p>Some projects have instructions on
 how to run <code>cpplint.py</code> from their project
 tools. If the project you are contributing to does not,
 you can download
 <a href="https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py">
 <code>cpplint.py</code></a> separately.</p>
-</div>
-
-
 
 <h2 id="Other_C++_Features">Other C++ Features</h2>
 
@@ -2243,14 +2223,10 @@ members.</p>
   nested functions, without the obscuring and error-prone
   bookkeeping of error codes.</li>
 
-
-
-  <div>
   <li>Exceptions are used by most other
   modern languages. Using them in C++ would make it more
   consistent with Python, Java, and the C++ that others
   are familiar with.</li>
-  </div>
 
   <li>Some third-party C++ libraries use exceptions, and
   turning them off internally makes it harder to
@@ -3746,9 +3722,6 @@ advanced template techniques, and an excessively
 
 <p class="decision"></p>
 
-
-
-<div>
 <p>In order to maintain a high level of readability for
 all contributors who might read and maintain code, we
 only allow an approved subset of Boost features.
@@ -3821,10 +3794,6 @@ Currently, the following libraries are permitted:</p>
 <p>We are actively considering adding other Boost
 features to the list, so this list may be expanded in
 the future.</p>
-</div>
-
-
-
 
 <h3 id="Other_Features"><a id="C++11">Other C++ Features</a></h3>
 
@@ -4242,10 +4211,10 @@ set_count(int count)</code>.</p>
 
 <h3 id="Namespace_Names">Namespace Names</h3>
 
-Namespace names are all lower-case, with words separated by underscores.
+<p>Namespace names are all lower-case, with words separated by underscores.
 Top-level namespace names are based on the project name
 . Avoid collisions
-between nested namespaces and well-known top-level namespaces.
+between nested namespaces and well-known top-level namespaces.</p>
 
 <p>The name of a top-level namespace should usually be the
 name of the project or team whose code is contained in that
@@ -4374,26 +4343,19 @@ comment and what style you use where.</p>
 
 <h3 id="File_Comments">File Comments</h3>
 
-<div>
 <p>Start each file with license boilerplate.</p>
-</div>
 
 <p>File comments describe the contents of a file. If a file declares,
 implements, or tests exactly one abstraction that is documented by a comment
 at the point of declaration, file comments are not required. All other files
 must have file comments.</p>
 
-<h4>Legal Notice and Author
-Line</h4>
+<h4>Legal Notice and Author Line</h4>
 
-
-
-<div>
 <p>Every file should contain license
 boilerplate. Choose the appropriate boilerplate for the
 license used by the project (for example, Apache 2.0,
 BSD, LGPL, GPL).</p>
-</div>
 
 <p>If you make significant changes to a file with an
 author line, consider deleting the author line.
@@ -4652,8 +4614,8 @@ if (std::find(v.begin(), v.end(), element) != v.end()) {
 }
 </pre>
 
-Self-describing code doesn't need a comment. The comment from
-the example above would be obvious:
+<p>Self-describing code doesn't need a comment. The comment from
+the example above would be obvious:</p>
 
 <pre>if (!IsAlreadyProcessed(element)) {
   Process(element);
@@ -4699,14 +4661,10 @@ person referenced will fix the problem. Thus when you create
 a <code>TODO</code> with a name, it is almost always your
 name that is given.</p>
 
-
-
-<div>
 <pre>// TODO(kl@gmail.com): Use a "*" here for concatenation operator.
 // TODO(Zeke) change this to use relations.
 // TODO(bug 12345): remove the "Last visitors" feature.
 </pre>
-</div>
 
 <p>If your <code>TODO</code> is of the form "At a future
 date do something" make sure that you either include a
@@ -4728,26 +4686,18 @@ style rules so that
 they can all read and understand
 everyone's code easily.</p>
 
-
-
-<div>
 <p>To help you format code correctly, we've created a
 <a href="https://raw.githubusercontent.com/google/styleguide/gh-pages/google-c-style.el">
 settings file for emacs</a>.</p>
-</div>
 
 <h3 id="Line_Length">Line Length</h3>
 
 <p>Each line of text in your code should be at most 80
 characters long.</p>
 
-
-
-<div>
 <p>We recognize that this rule is
 controversial, but so much existing code already adheres
 to it, and we feel that consistency is important.</p>
-</div>
 
 <p class="pros"></p>
 <p>Those who favor  this rule
@@ -5211,7 +5161,6 @@ case should never execute, treat this as an error. For example:
 
 </p>
 
-<div>
 <pre>switch (var) {
   case 0: {  // 2 space indent
     ...      // 4 space indent
@@ -5226,7 +5175,6 @@ case should never execute, treat this as an error. For example:
   }
 }
 </pre>
-</div>
 
 <p>Fall-through from one case label to
 another must be annotated using the
@@ -5327,9 +5275,10 @@ file.
 When modifying an existing file, use the style in
 that file.</p>
 
-It is allowed (if unusual) to declare multiple variables in the same
+<p>It is allowed (if unusual) to declare multiple variables in the same
 declaration, but it is disallowed if any of those have pointer or
-reference decorations. Such declarations are easily misread.
+reference decorations. Such declarations are easily misread.</p>
+
 <pre>// Fine if helpful for readability.
 int x, y;
 </pre>
@@ -5711,9 +5660,6 @@ useful:</p>
 However, like all good rules, these sometimes have exceptions,
 which we discuss here.</p>
 
-
-
-<div>
 <h3 id="Existing_Non-conformant_Code">Existing Non-conformant Code</h3>
 
 <p>You may diverge from the rules when dealing with code that
@@ -5727,10 +5673,6 @@ code. If you are in doubt about how to do this, ask the
 original author or the person currently responsible for
 the code. Remember that <em>consistency</em> includes
 local consistency, too.</p>
-
-</div>
-
-
 
 <h3 id="Windows_Code">Windows Code</h3>
 

--- a/cppguide.html
+++ b/cppguide.html
@@ -958,7 +958,7 @@ does not make an observable difference. For example:</p>
 <ul>
   <li>Global strings: if you require a named global or static string constant,
     consider using a <code>constexpr</code> variable of
-    <code>string_view</code>, character array, or character pointer, pointing
+    <code>std::string_view</code>, character array, or character pointer, pointing
     to a string literal. String literals have static storage duration already
     and are usually sufficient.
     See <a href="https://abseil.io/tips/140">TotW #140.</a></li>
@@ -979,7 +979,7 @@ does not make an observable difference. For example:</p>
     If you do really prefer a dynamic container from the standard library, consider using
     a function-local static pointer, as described below
     .</li>
-  <li>Smart pointers (<code>unique_ptr</code>, <code>shared_ptr</code>): smart
+  <li>Smart pointers (<code>std::unique_ptr</code>, <code>std::shared_ptr</code>): smart
     pointers execute cleanup during destruction and are therefore forbidden.
     Consider whether your use case fits into one of the other patterns described
     in this section. One simple solution is to use a plain pointer to a
@@ -1190,7 +1190,7 @@ language treats it as one as far as <code>explicit</code> is concerned.
     when it's obvious.</li>
 <li>Implicit conversions can be a simpler alternative to
     overloading, such as when a single
-    function with a <code>string_view</code> parameter takes the
+    function with a <code>std::string_view</code> parameter takes the
     place of separate overloads for <code>std::string</code> and
     <code>const char*</code>.</li>
 <li>List initialization syntax is a concise and expressive
@@ -1519,7 +1519,7 @@ that <code>Bar</code> "is a kind of"
 <p>Limit the use of <code>protected</code> to those
 member functions that might need to be accessed from
 subclasses. Note that <a href="#Access_Control">data
-members should be private</a>.</p>
+members should be <code>private</code></a>.</p>
 
 <p>Explicitly annotate overrides of virtual functions or virtual
 destructors with exactly one of an <code>override</code> or (less
@@ -1629,7 +1629,7 @@ built-in operators. For example, use <code>|</code> as a
 bitwise- or logical-or, not as a shell-style pipe.</p>
 
 <p>Define operators only on your own types. More precisely,
-define them in the same headers, .cc files, and namespaces
+define them in the same headers, <code>.cc</code> files, and namespaces
 as the types they operate on. That way, the operators are available
 wherever the type is, minimizing the risk of multiple
 definitions. If possible, avoid defining operators as templates,
@@ -1681,18 +1681,18 @@ apply to operator overloading as well.</p>
 of some easy boilerplate in the form of accessors (usually <code>const</code>) if necessary.</p>
 
 <p>For technical
-reasons, we allow data members of a test fixture class defined in a .cc file to
+reasons, we allow data members of a test fixture class defined in a <code>.cc</code> file to
 be <code>protected</code> when using
 
 
 <a href="https://github.com/google/googletest">Google
 Test</a>.
-If a test fixture class is defined outside of the .cc file it is used in, for example in a .h file,
+If a test fixture class is defined outside of the <code>.cc</code> file it is used in, for example in a <code>.h</code> file,
 make data members <code>private</code>.</p>
 
 <h3 id="Declaration_Order">Declaration Order</h3>
 
-<p>Group similar declarations together, placing public parts
+<p>Group similar declarations together, placing <code>public</code> parts
 earlier.</p>
 
 <p>A class definition should usually start with a
@@ -1812,8 +1812,8 @@ which overload is being called.</p>
 <p>You may write a function that takes a <code>const
 std::string&amp;</code> and overload it with another that
 takes <code>const char*</code>. However, in this case consider
-std::string_view
- instead.</p>
+<code>std::string_view</code>
+instead.</p>
 
 <pre>class MyClass {
  public:
@@ -1827,7 +1827,7 @@ std::string_view
 identically-named function to take different arguments.
 It may be necessary for templatized code, and it can be
 convenient for Visitors.</p>
-<p>Overloading based on const or ref qualification may make utility
+<p>Overloading based on <code>const</code> or ref qualification may make utility
   code more usable, more efficient, or both.
   (See <a href="http://abseil.io/tips/148">TotW 148</a> for more.)
 </p>
@@ -2030,7 +2030,7 @@ all copies, and the object is deleted when the last
   bookkeeping, simplifying the code and ruling out large
   classes of errors.</li>
 
-  <li>For const objects, shared ownership can be a simple
+  <li>For <code>const</code> objects, shared ownership can be a simple
   and efficient alternative to deep copying.</li>
 </ul>
 
@@ -2133,9 +2133,9 @@ are a type of reference that can only bind to temporary
 objects. The syntax is similar to traditional reference
 syntax. For example, <code>void f(std::string&amp;&amp;
 s);</code> declares a function whose argument is an
-rvalue reference to a std::string.</p>
+rvalue reference to a <code>std::string</code>.</p>
 
-<p id="Forwarding_references"> When the token '&amp;&amp;' is applied to
+<p id="Forwarding_references"> When the token <code>&amp;&amp;</code> is applied to
 an unqualified template argument in a function
 parameter, special template argument deduction
 rules apply. Such a reference is called forwarding reference.</p>
@@ -2227,7 +2227,7 @@ make a unittest class a friend of the class it tests.</p>
 
 <p>Friends extend, but do not break, the encapsulation
 boundary of a class. In some cases this is better than
-making a member public when you want to give only one
+making a member <code>public</code> when you want to give only one
 other class access to it. However, most classes should
 interact with other classes solely through their public
 members.</p>
@@ -2533,8 +2533,8 @@ like <code>static_cast&lt;float&gt;(double_value)</code>, or brace
 initialization for conversion of arithmetic types like
 <code>int64_t y = int64_t{1} &lt;&lt; 42</code>. Do not use
 cast formats like <code>(int)x</code> unless the cast is to
-<code>void</code>. You may use cast formats like `T(x)` only when
-`T` is a class type.</p>
+<code>void</code>. You may use cast formats like <code>T(x)</code> only when
+<code>T</code> is a class type.</p>
 
 <p class="definition"></p>
 <p> C++ introduced a
@@ -2797,7 +2797,7 @@ many other contexts as well. In particular:</p>
 
   </li><li>Declare methods to be <code>const</code> unless they
   alter the logical state of the object (or enable the user to modify
-  that state, e.g., by returning a non-const reference, but that's
+  that state, e.g., by returning a non-<code>const</code> reference, but that's
   rare), or they can't safely be invoked concurrently.</li>
 </ul>
 
@@ -2850,9 +2850,9 @@ types; and definition of constants with function
 calls.</p>
 
 <p class="cons"></p>
-<p>Prematurely marking something as constexpr may cause
+<p>Prematurely marking something as <code>constexpr</code> may cause
 migration problems if later on it has to be downgraded.
-Current restrictions on what is allowed in constexpr
+Current restrictions on what is allowed in <code>constexpr</code>
 functions and constructors may invite obscure workarounds
 in these definitions.</p>
 
@@ -3918,7 +3918,7 @@ using other_namespace::Foo;
 
   <p>Like other declarations, aliases declared in a header file are part of that
   header's public API unless they're in a function definition, in the private portion of a class,
-  or in an explicitly-marked internal namespace. Aliases in such areas or in .cc files are
+  or in an explicitly-marked internal namespace. Aliases in such areas or in <code>.cc</code> files are
   implementation details (because client code can't refer to them), and are not restricted by this
   rule.</p>
 
@@ -3979,8 +3979,8 @@ typedef unordered_set&lt;DataPoint, hash&lt;DataPoint&gt;, DataPointComparator&g
 }  // namespace mynamespace
 </pre>
 
-<p>However, local convenience aliases are fine in function definitions, private sections of
-  classes, explicitly marked internal namespaces, and in .cc files:</p>
+<p>However, local convenience aliases are fine in function definitions, <code>private</code> sections of
+  classes, explicitly marked internal namespaces, and in <code>.cc</code> files:</p>
 
 <pre>// In a .cc file
 using ::foo::Bar;
@@ -4202,7 +4202,7 @@ versus a class.</p>
 
 <h3 id="Constant_Names">Constant Names</h3>
 
-<p>Variables declared constexpr or const, and whose value is fixed for
+<p>Variables declared <code>constexpr</code> or <code>const</code>, and whose value is fixed for
 the duration of the program, are named with a leading "k" followed
 by mixed case. Underscores can be used as separators in the rare cases
 where capitalization cannot be used for separation. For example:</p>
@@ -4455,7 +4455,7 @@ operation.</p>
 preceding it that describe what the function does and how to use
 it. These comments may be omitted only if the function is simple and
 obvious (e.g., simple accessors for obvious properties of the class).
-Private methods and functions declared in `.cc` files are not exempt.
+Private methods and functions declared in <code>.cc</code> files are not exempt.
 Function comments should be written with an implied subject of
 <i>This function</i> and should start with the verb phrase; for example,
 "Opens the file", rather than "Open the file". In general, these comments do not


### PR DESCRIPTION
- Added missing `std::` namespace to classes in the standard library e.g., `string_view`.
- Added missing &lt;code&gt; tag to keywords and file extensions where missing.
- Fixed all paragraphs to use &lt;p&gt; tag.
- Removed unnecessary &lt;div&gt; tags.