### PR TITLE
fix: broken link due to spacing

### DIFF
--- a/docguide/best_practices.md
+++ b/docguide/best_practices.md
@@ -1,7 +1,6 @@
 # Documentation Best Practices
 
-"Say what you mean, simply and directly." - [Brian Kernighan]
-(https://en.wikipedia.org/wiki/The_Elements_of_Programming_Style)
+"Say what you mean, simply and directly." - [Brian Kernighan](https://en.wikipedia.org/wiki/The_Elements_of_Programming_Style)
 
 Contents:
 


### PR DESCRIPTION
the first paragraph, 
> "Say what you mean, simply and directly." - [Brian Kernighan] (https://en.wikipedia.org/wiki/The_Elements_of_Programming_Style)

which brokes the link since the markdown syntax is incorrect, I think the best practice for this best practice is to fix the best practice.

this PR fixes a broken link since the space between `[]` and `()` in the markdown, should not appear here.