### PR TITLE
Fix PRINT-UNPRINTABLE-OBJECT

### DIFF
--- a/lispguide.xml
+++ b/lispguide.xml
@@ -2087,7 +2087,7 @@ Robert Brown
       </p>
       <CODE_SNIPPET>
         (defmethod print-object ((p person) stream)
-          (print-unprintable-object (p stream :type t :identity t)
+          (print-unreadable-object (p stream :type t :identity t)
             (with-slots (first-name last-name) p
               (safe-format stream "~a ~a" first-name last-name))))
       </CODE_SNIPPET>


### PR DESCRIPTION
There is no Common Lisp operator named PRINT-UNPRINTABLE-OBJECT. Given the context, it is certain that PRINT-UNREADABLE-OBJECT (www.lispworks.com/documentation/lw51/CLHS/Body/m_pr_unr.htm) was meant instead.