### PR TITLE
Avoid IWYU warnings on other namespaces for <algorithm>.

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5398,7 +5398,7 @@ for _header, _templates in _HEADERS_MAYBE_TEMPLATES:
   for _template in _templates:
     # Match max<type>(..., ...), max(..., ...), but not foo->max or foo.max.
     _re_pattern_headers_maybe_templates.append(
-        (re.compile(r'(?<![>.]\b)' + _template + r'(<.*?>)?\([^\)]'), _template,
+        (re.compile(r'(?<![>.])\b' + _template + r'(<.*?>)?\([^\)]'), _template,
          _header))
 
 # Other scripts may reach in and modify this pattern.

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -969,6 +969,11 @@ class CpplintTest(CpplintTestBase):
         """,
         '')
     self.TestIncludeWhatYouUse(
+        """#include "base/ranges/algorithm.h"
+          base::ranges::copy(foo, bar.begin());
+        """,
+        '')
+    self.TestIncludeWhatYouUse(
         """#include "base/foobar.h"
            bool foobar = std::less<int>(0,1);
         """,

--- a/cpplint/cpplint_unittest.py
+++ b/cpplint/cpplint_unittest.py
@@ -975,6 +975,11 @@ class CpplintTest(CpplintTestBase):
         '')
     self.TestIncludeWhatYouUse(
         """#include "base/foobar.h"
+          void FooBar::Remove(size_t index);
+        """,
+        '')
+    self.TestIncludeWhatYouUse(
+        """#include "base/foobar.h"
            bool foobar = std::less<int>(0,1);
         """,
         'Add #include <functional> for less<>'


### PR DESCRIPTION
This is an extension of the logic already used for other STL headers.