### PR TITLE
Go: Fix a logic error in an example.

### DIFF
--- a/go/decisions.md
+++ b/go/decisions.md
@@ -3371,7 +3371,7 @@ some other error, then consider using `cmp` with [`cmpopts.EquateErrors`].
 >
 > ```go
 > // Good:
-> gotErr := f(test.input) == nil
+> gotErr := f(test.input) != nil
 > if gotErr != test.wantErr {
 >     t.Errorf("f(%q) returned err = %v, want error presence = %v", test.input, gotErr, test.wantErr)
 > }


### PR DESCRIPTION
PiperOrigin-RevId: 489255983
