### PR TITLE
Fix go-cmp Links

### DIFF
--- a/go/decisions.md
+++ b/go/decisions.md
@@ -3217,8 +3217,8 @@ It is user-configurable and should serve most comparison needs.
 
 [language-defined comparisons]: http://golang.org/ref/spec#Comparison_operators
 [`cmp`]: https://pkg.go.dev/github.com/google/go-cmp/cmp
-[`cmp.Equal`]: https://pkg.go.dev/github.com/google/go-cmp/cmp/cmp#Equal
-[`cmp.Diff`]: https://pkg.go.dev/github.com/google/go-cmp/cmp/cmp#Diff
+[`cmp.Equal`]: https://pkg.go.dev/github.com/google/go-cmp/cmp#Equal
+[`cmp.Diff`]: https://pkg.go.dev/github.com/google/go-cmp/cmp#Diff
 [`protocmp.Transform`]: https://pkg.go.dev/google.golang.org/protobuf/testing/protocmp#Transform
 
 Existing code may make use of the following older libraries, and may continue


### PR DESCRIPTION
Fix two broken links within the Go styleguide.

Great work by the way :)