### PR TITLE
Trivial typofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project holds the [C++ Style Guide][cpp], [C# Style Guide][csharp],
 [Java Style Guide][java], [Python Style Guide][py], [R Style Guide][r],
 [Shell Style Guide][sh], [HTML/CSS Style Guide][htmlcss],
 [JavaScript Style Guide][js], [TypeScript Style Guide][ts], [AngularJS Style Guide][angular],
-[Common Lisp Style Guide][cl], and [Vimscript Style Guide][vim]. This project
+[Common Lisp Style Guide][cl], and [Vim script Style Guide][vim]. This project
 also contains [cpplint][cpplint], a tool to assist with style guide compliance,
 and [google-c-style.el][emacs], an Emacs settings file for Google style.
 


### PR DESCRIPTION
s/Vimscript/Vim script/

The below does not seem to apply to this changeset:

---

These style guides are copies of Google's internal style guides to
assist developers working on Google owned and originated open source
projects. Changes should be made to the internal style guide first and
only then copied here.

Unsolicited pull requests will not be merged and are usually closed
without comment. If a PR points out a simple mistake — a typo, a broken
link, etc. — then the correction can be made internally and copied here
through the usual process.

Substantive changes to the style rules and suggested new rules should
not be submitted as a PR in this repository. Material changes must be
proposed, discussed, and approved on the internal forums first.
