### PR TITLE
[go] Fix a minor code-example bug

### DIFF
--- a/go/decisions.md
+++ b/go/decisions.md
@@ -1494,7 +1494,7 @@ import (
 )
 
 ldb := leveldb.Open("/my/table", &db.Options{
-    BlockSize int: 1<<16,
+    BlockSize: 1<<16,
     ErrorIfDBExists: true,
 
     // These fields all have their zero values.
@@ -1517,7 +1517,7 @@ import (
 )
 
 ldb := leveldb.Open("/my/table", &db.Options{
-    BlockSize int: 1<<16,
+    BlockSize: 1<<16,
     ErrorIfDBExists: true,
 })
 ```


### PR DESCRIPTION
In the Zero-value fields section there is a minor mistake in the code examples, this change removes that.

PS: Thanks for making these styleguides publicly available!