### PR TITLE
cppguide: update obsolete protocol-buffers documentation link

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -688,7 +688,7 @@ using ::foo::Bar;
   <code>.proto</code> file. See
 
 
-  <a href="https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#package">
+  <a href="https://protobuf.dev/reference/cpp/cpp-generated/#package">
   Protocol Buffer Packages</a>
   for details.</li>
 


### PR DESCRIPTION
NOTE: This site is deprecated. The site will be turned down after January 31, 2023, and traffic will redirect to the new site at https://protobuf.dev. In the meantime, updates will be made only to protobuf.dev. https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#package

These style guides are copies of Google's internal style guides to
assist developers working on Google owned and originated open source
projects. Changes should be made to the internal style guide first and
only then copied here.

Unsolicited pull requests will not be merged and are usually closed
without comment. If a PR points out a simple mistake — a typo, a broken
link, etc. — then the correction can be made internally and copied here
through the usual process.

Substantive changes to the style rules and suggested new rules should
not be submitted as a PR in this repository. Material changes must be
proposed, discussed, and approved on the internal forums first.
