### PR TITLE
The base_name should fully match the exclude_files pattern

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5989,7 +5989,7 @@ def ProcessConfigOverrides(filename):
             # and not "baz" nor "bar/baz.cc".
             if base_name:
               pattern = re.compile(val)
-              if pattern.match(base_name):
+              if pattern.fullmatch(base_name):
                 if _cpplint_state.quiet:
                   # Suppress "Ignoring file" warning when using --quiet.
                   return False


### PR DESCRIPTION
Previously, a path in the same directory as the CPPLINT.cfg is excluded if one of its prefixes matches the pattern, which leads some confusing cases like "exclude_files=l" excluding "libs". With this change we should change the pattern to "exclude_files=l.*" to achieve the same result.
