### PR TITLE
[IntelliJ] (Add) line comment not start at first column & add space

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -110,6 +110,9 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
+    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+    <option name="LINE_COMMENT_ADD_SPACE" value="true" />
+    <option name="LINE_COMMENT_ADD_SPACE_ON_REFORMAT" value="true" />
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />

--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -136,6 +136,7 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="ENUM_CONSTANTS_WRAP" value="2" />
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
       <option name="CONTINUATION_INDENT_SIZE" value="4" />


### PR DESCRIPTION
By default, IntelliJ add line comment at first column
Example, when pressing `Ctrl + /` at line 3, this file
```
public class Main {
  public static void main(String[] args) {
    System.out.println("Hello world!");
  }
}
```
becomes
```
public class Main {
  public static void main(String[] args) {
//    System.out.println("Hello world!");
  }
}
```
With these configs, that file becomes
```
public class Main {
  public static void main(String[] args) {
    // System.out.println("Hello world!");
  }
}
```