### PR TITLE
Inline function defintion error

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -355,9 +355,7 @@ defined in another project.</p>
 lines or fewer.</p>
 
 <p class="definition"></p>
-<p>You can declare functions in a way that allows the compiler to expand
-them inline rather than calling them through the usual
-function call mechanism.</p>
+<p>Declaring a function inline suggests that the compiler replace every call to that function with code in the function definition, rather than calling them through the usual function call mechanism.</p>
 
 <p class="pros"></p>
 <p>Inlining a function can generate more efficient object

--- a/cppguide.html
+++ b/cppguide.html
@@ -355,7 +355,10 @@ defined in another project.</p>
 lines or fewer.</p>
 
 <p class="definition"></p>
-<p>Declaring a function inline suggests that the compiler replace every call to that function with code in the function definition, rather than calling them through the usual function call mechanism.</p>
+<p>Declaring a function inline suggests that the compiler 
+replace every call to that function with code in the 
+function definition, rather than calling them through the 
+usual function call mechanism.</p>
 
 <p class="pros"></p>
 <p>Inlining a function can generate more efficient object


### PR DESCRIPTION
The original description is unclear:

> You can declare functions in a way that allows the compiler to expand them inline rather than calling them through the usual function call mechanism.

I think it should be emphasized that defining inline functions, whether with the standard C++ keyword 'inline' or some other compiler extension, is just a 'suggestion'. The original text seems unclear.

The compiler can inline a function whether or not it is defined inline.

[cppreference](https://en.cppreference.com/w/cpp/language/inline):

>Since this meaning of the keyword inline is non-binding, compilers are free to use inline substitution for any function that's not marked inline, and are free to generate function calls to any function marked inline. Those optimization choices do not change the rules regarding multiple definitions and shared statics listed above.

> Inline variables eliminate the main obstacle to packaging C++ code as header-only libraries.
(since C++17)

---

In the previous Microsoft documentation, there was also some discussion of inline functions:

https://github.com/MicrosoftDocs/cpp-docs/pull/4823

