### PR TITLE
Correction: jsguide.html - Changed null to undefined

### DIFF
--- a/jsguide.html
+++ b/jsguide.html
@@ -1413,7 +1413,7 @@ if (o.hasOwnProperty('maxWidth')) {
 
 <pre><code class="language-js prettyprint">/** @type {{width: number, maxWidth: (number|undefined)}} */
 const o = {width: 42};
-if (o.maxWidth != null) {
+if (o.maxWidth != undefined) {
   ...
 }
 </code></pre>


### PR DESCRIPTION
## This change is "Not important".
Please don't review this leaving your work behind.

## Change description 
Keys not defined in an Object are undefined.
``` javascript
const o = {width: 42};
o.maxWidth === null // false
o.maxWidth === undefined // true
```
<img width="211" alt="image" src="https://github.com/google/styleguide/assets/12816899/b4214661-6da0-4882-b3d5-b04bf9857d29">
