### PR TITLE
Clarify include order

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -399,10 +399,8 @@ mutators.</p>
 <p>Include headers in the following order: Related header, C system headers,
 C++ standard library headers,
 other libraries' headers, your project's
-headers.\b
-i
-The includes should be ordered alphabetically. This ordering should be case-sensitive, meaningthat uppercase and lowercase letters are considered to be different</p>
-  
+headers.
+The includes should be ordered alphabetically. This ordering should be case-sensitive, meaningthat uppercase and lowercase letters are considered to be different</p> 
 <p>
 All of a project's header files should be
 listed as descendants of the project's source

--- a/cppguide.html
+++ b/cppguide.html
@@ -399,8 +399,9 @@ mutators.</p>
 <p>Include headers in the following order: Related header, C system headers,
 C++ standard library headers,
 other libraries' headers, your project's
-headers.</p>
-
+headers.\b
+The includes should be ordered alphabetically. This ordering should be case-sensitive, meaningthat uppercase and lowercase letters are considered different</p>
+  
 <p>
 All of a project's header files should be
 listed as descendants of the project's source

--- a/cppguide.html
+++ b/cppguide.html
@@ -400,7 +400,8 @@ mutators.</p>
 C++ standard library headers,
 other libraries' headers, your project's
 headers.\b
-The includes should be ordered alphabetically. This ordering should be case-sensitive, meaningthat uppercase and lowercase letters are considered different</p>
+i
+The includes should be ordered alphabetically. This ordering should be case-sensitive, meaningthat uppercase and lowercase letters are considered to be different</p>
   
 <p>
 All of a project's header files should be


### PR DESCRIPTION
 The current documentation does not specify whether the include order should be case-sensitive or case-insensitive, leading to ambiguity and inconsistencies in automated tools.

This Pull Request adds a note to clarify that the include order should be case-sensitive, in line with typical programmatic ordering.

Added a note in the "Names and Order of Includes" section to specify that the ordering should be case-sensitive.