### PR TITLE
Fix typos

### DIFF
--- a/docguide/best_practices.md
+++ b/docguide/best_practices.md
@@ -136,6 +136,6 @@ to detailed prose:
 
 Do not write your own guide to a common Google technology or process. Link to it
 instead. If the guide doesn't exist or it's badly out of date, submit your
-updates to the appriopriate directory or create a package-level
+updates to the appropriate directory or create a package-level
 README.md. **Take ownership and don't be shy**: Other teams will usually welcome
 your contributions.

--- a/objcguide.md
+++ b/objcguide.md
@@ -1180,7 +1180,7 @@ TimeZoneMappingSet *timeZoneMappings = [TimeZoneMappingSet setWithObjects:...];
 
 Use the most descriptive common superclass or protocol available. In the most
 generic case when nothing else is known, declare the collection to be explicitly
-heterogenous using id.
+heterogeneous using id.
 
 ```objectivec 
 // GOOD:


### PR DESCRIPTION
Fix typos in documentation, comments, etc.

Via [codespell](https://github.com/codespell-project/codespell/).