### PR TITLE
pylintrc: disable score reports

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -141,6 +141,9 @@ output-format=text
 # Tells whether to display a full report or only the messages
 reports=no
 
+# Activate the evaluation score.
+score=no
+
 # Python expression which should return a note less than 10 (10 is the highest
 # note). You have access to the variables errors warning, statement which
 # respectively contain the number of errors / warnings messages and the total


### PR DESCRIPTION
We disable reports in general already, but newer pylint versions include per-file score reports by default.

PiperOrigin-RevId: 725563567