### PR TITLE
GitHub: Refresh Code Owners for Current Go Admins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@ lispguide.xml @sfreilich
 pyguide.md @gpshead
 pylintrc @gpshead
 shellguide.md @dimo414 @eatnumber1 @vapier
-/go/ @carrotman42 @gaal @matttproud
+/go/ @carrotman42 @chressie @gaal @katrinahoffert @kliegs @matttproud

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@ lispguide.xml @sfreilich
 pyguide.md @gpshead
 pylintrc @gpshead
 shellguide.md @dimo414 @eatnumber1 @vapier
-/go/ @carrotman42 @chressie @gaal @katrinahoffert @kliegs @matttproud
+/go/ @chressie @gaal @katrinahoffert @kliegs @matttproud


### PR DESCRIPTION
The current Go Readability Approvers administration group has grown
over the last few years, so we should refresh the code owners to
make maintenance of the external style guide easier.  This also
lightens the geographic load for reviews, too.