### PR TITLE
docs: clarify map(parseInt) example with explicit radix

### DIFF
--- a/tsguide.html
+++ b/tsguide.html
@@ -1561,8 +1561,8 @@ const numbers = ['11', '5', '10'].map(parseInt);
 <p>Instead, prefer passing an arrow-function that explicitly forwards parameters to
 the named callback.</p>
 
-<pre><code class="language-ts good">// GOOD: we only forward the string (and an explicit radix)
-const numbers = ['11', '5', '3'].map((n) =&gt; parseInt(n,10));
+<pre><code class="language-ts good">// GOOD: Arguments are explicitly passed to the callback
+const numbers = ['11', '5', '3'].map((n) =&gt; parseInt(n, 10));
 // &gt; [11, 5, 3]
 
 // GOOD: Function is locally defined and is designed to be used as a callback

--- a/tsguide.html
+++ b/tsguide.html
@@ -1561,8 +1561,8 @@ const numbers = ['11', '5', '10'].map(parseInt);
 <p>Instead, prefer passing an arrow-function that explicitly forwards parameters to
 the named callback.</p>
 
-<pre><code class="language-ts good">// GOOD: Arguments are explicitly passed to the callback
-const numbers = ['11', '5', '3'].map((n) =&gt; parseInt(n));
+<pre><code class="language-ts good">// GOOD: we only forward the string (and an explicit radix)
+const numbers = ['11', '5', '3'].map((n) =&gt; parseInt(n,10));
 // &gt; [11, 5, 3]
 
 // GOOD: Function is locally defined and is designed to be used as a callback


### PR DESCRIPTION
Use an arrow-function callback to explicitly forward only the string and a radix of 10 to parseInt:

// GOOD: we only forward the string (and an explicit radix)
['11','5','3'].map(n => parseInt(n, 10)); // [11, 5, 3]

