### PR TITLE
update google/code-prettify load URL

### DIFF
--- a/include/jsguide.js
+++ b/include/jsguide.js
@@ -57,7 +57,7 @@ window.initStyleGuide = function(init) {
 
   // Call the pretty-printer after we've fixed up the code blocks.
   var pretty = document.createElement('script');
-  pretty.src = 'https://cdn.rawgit.com/google/code-prettify/master/loader/' +
-      'run_prettify.js';
+  pretty.src = 'https://cdn.jsdelivr.net/gh/google/code-prettify@master/' +
+      'loader/run_prettify.js';
   document.body.appendChild(pretty);
 }.bind(null, window.initStyleGuide);

--- a/javaguide.html
+++ b/javaguide.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" href="javaguide.css">
 <script src="include/styleguide.js"></script>
 <link rel="shortcut icon" href="/styleguide/favicon.ico">
-<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
 </head>
 <body onload="initStyleGuide();">
 <div id="content">


### PR DESCRIPTION
The rawgit service was shutdown in 2019, and people are supposed to migrate to cdn.jsdelivr.net.
https://groups.google.com/g/js-code-prettifier/c/IFHev_kLm30