### PR TITLE
Add styling rules for good code examples in shared stylesheet

### DIFF
--- a/include/styleguide.css
+++ b/include/styleguide.css
@@ -59,10 +59,13 @@ code, samp, var {
 }
 
 pre {
-  padding:6px 10px;
-  background-color:#FAFAFA;
-  border:1px solid #bbb;
-  overflow:auto;
+  background-color: #e9e9e9;
+  color: #333;
+  border-color: #f9f9f9;
+  border-style: solid;
+  border-width: 1px 1px 1px 5px;
+  overflow: auto;
+  padding: 6px 12px;
 }
 
 pre.prettyprint {
@@ -70,14 +73,16 @@ pre.prettyprint {
   border:1px solid #bbb !important;
 }
 
-code.bad, code.badcode {
-  color: magenta;
+pre.bad, pre.badcode {
+  background-color: #ffe6d8;
+  border-color: #fff0f0;
+  color: #c00;
 }
 
-pre.bad, pre.badcode {
-  background-color:#ffe6d8;
-  border-top:1px inset #a03;
-  border-left:1px inset #a03;
+pre.good, pre.goodcode {
+  background-color: #e8fff6;
+  color: #060;
+  border-color: #f0fff0;
 }
 
 hr {


### PR DESCRIPTION
This change primarily affects the C++ style guide: while a number of other style guides also use `<pre>` directly for code examples, the other style guides all use JS to prettyprint the code blocks, and the prettyprinter overrides the styles specified in the shared stylesheet.

The exception is the AngularJS style guide, but it is already inconsistently formatted and this change does not make it any worse.

There are also several other style guides other than C++ where good/neutral are rendered identically; this commit does not attempt to address those either.

I copied the CSS rules from the internal C++ style guide. I did not attempt to make everything consistent; just the rules for `<pre>` and badcode/goodcode.

As far as I can tell:
- `styleguide.css` is not derived from anything internal, nor is it automatically updated
- Before: https://google.github.io/styleguide/cppguide.html
- After: https://zetafunction.github.io/styleguide/cppguide.html
- There is some question of how `<pre>` with no class should be treated; I have opted to treat them as neutral here, though the internal style guide seems to treat them as good by default (which also seems wrong). That will be separately resolved.
- Other style guides that use `<pre>` for code formatting do not appear to be affected by this; they use a pretty printing script:
  - https://zetafunction.github.io/styleguide/angularjs-google-style.html
  - https://zetafunction.github.io/styleguide/javaguide.html
  - https://zetafunction.github.io/styleguide/jsguide.html
  - https://zetafunction.github.io/styleguide/tsguide.html