### PR TITLE
go: Fix variable name example typo.

### DIFF
--- a/go/decisions.md
+++ b/go/decisions.md
@@ -405,7 +405,7 @@ If the value appears in multiple forms, this can be clarified either with an
 extra word like `raw` and `parsed` or with the underlying representation:
 
 ```go
-// Good:
+// Bad:
 limitStr := r.FormValue("limit")
 limit, err := strconv.Atoi(limitStr)
 ```


### PR DESCRIPTION
The first code example under 'Variable name vs. type' is clearly meant to be commented as a 'bad' example.