### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,8 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.css,.codespellrc,LICENSE
+check-hidden = true
+# Case sensitive etc. Python regex
+ignore-regex = \b(CLOS|oh noes|xmlns:\S+)\b|github\.com/dsnet/compress/flate|Use "\S+".* not "\S+"
+# Unfortunate/suboptimal choices of variables/words
+ignore-words-list = anumber,afile,statics

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [gh-pages]
+  pull_request:
+    branches: [gh-pages]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/cppguide.html
+++ b/cppguide.html
@@ -1583,7 +1583,7 @@ methods); all other inheritance is "implementation
 inheritance".</p>
 
 <p class="pros"></p>
-<p>Implementation inheritance reduces code size by re-using
+<p>Implementation inheritance reduces code size by reusing
 the base class code as it specializes an existing type.
 Because inheritance is a compile-time declaration, you
 and the compiler can understand the operation and detect

--- a/htmlcssguide.html
+++ b/htmlcssguide.html
@@ -173,7 +173,7 @@ by including <code>&lt;!doctype html&gt;</code> at the beginning of the document
 different doctype may be rendered in “limited-quirks mode”. These modes don’t
 follow the widely-understood, widely-documented behavior for various core HTML
 and CSS constructs, and are likely to cause subtle failures and
-incompatibilities especially when re-using code that expects no-quirks mode.</p>
+incompatibilities especially when reusing code that expects no-quirks mode.</p>
 
 <h4 id="HTML_Validity" class="numbered">HTML Validity</h4>
 

--- a/jsoncstyleguide.xml
+++ b/jsoncstyleguide.xml
@@ -201,7 +201,7 @@ Avoid naming conflicts by choosing a new property name or versioning the API.
   "data": {
     "recipeName": "pizza",
     "ingredients": "Some new property",
-    "recipeIngredients": ["tomatos", "cheese", "sausage"]
+    "recipeIngredients": ["tomatoes", "cheese", "sausage"]
   }
 }
 

--- a/lispguide.xml
+++ b/lispguide.xml
@@ -2054,7 +2054,7 @@ Robert Brown
         but sometimes, fixups are necessary to resolve forward references,
         and intercession is allowed then.
         MOP intercession is a great tool for interactive development,
-        and you may enjoy it while developping and debugging;
+        and you may enjoy it while developing and debugging;
         but you should not use it in normal applications.
       </p>
       <p>

--- a/pylintrc
+++ b/pylintrc
@@ -59,7 +59,7 @@ confidence=
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once).You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
+# disable everything first and then re-enable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

It was requested a while back in
- https://github.com/BerriAI/litellm/pull/10232#issuecomment-2826300701

and recommended in
- https://github.com/BerriAI/litellm/issues/5991#issuecomment-2388853171

there indeed could be some false positives but I think it is quite robust -- you can see how few I had to exclude, and some of those could actually be "fixed" to make it cleaner