### PR TITLE
Update C++ style guide

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -5557,12 +5557,12 @@ if (condition1 &amp;&amp;
   DoSomething();
 </pre>
 
-<p>For historical reasons, we allow one exception to the above rules: the curly
-braces for the controlled statement or the line breaks inside the curly braces
-may be omitted if as a result the entire statement appears on either a single
-line (in which case there is a space between the closing parenthesis and the
-controlled statement) or on two lines (in which case there is a line break
-after the closing parenthesis and there are no braces).</p>
+<p>For historical reasons, we allow, but discourage, one exception to the above
+rules: the curly braces for the controlled statement or the line breaks inside
+the curly braces may be omitted if as a result the entire statement appears on
+either a single line (in which case there is a space between the closing
+parenthesis and the controlled statement) or on two lines (in which case there
+is a line break after the closing parenthesis and there are no braces).</p>
 
 <pre class="neutralcode">// OK - fits on one line.
 if (x == kFoo) { return new Foo(); }


### PR DESCRIPTION
One small update to clarify that omitting braces on control blocks is permitted but discouraged.

These style guides are copies of Google's internal style guides to
assist developers working on Google owned and originated open source
projects. Changes should be made to the internal style guide first and
only then copied here.

Unsolicited pull requests will not be merged and are usually closed
without comment. If a PR points out a simple mistake — a typo, a broken
link, etc. — then the correction can be made internally and copied here
through the usual process.

Substantive changes to the style rules and suggested new rules should
not be submitted as a PR in this repository. Material changes must be
proposed, discussed, and approved on the internal forums first.
