### PR TITLE
Standardize fenced code block formatting and add missing language tags

### DIFF
--- a/Rguide.md
+++ b/Rguide.md
@@ -18,7 +18,7 @@ and why these differences exist.
 Google prefers identifying functions with `BigCamelCase` to clearly distinguish
 them from other objects.
 
-```
+```r
 # Good
 DoNothing <- function() {
   return(invisible(NULL))
@@ -28,7 +28,7 @@ DoNothing <- function() {
 The names of private functions should begin with a dot. This helps communicate
 both the origin of the function and its intended use.
 
-```
+```r
 # Good
 .DoNothingPrivately <- function() {
   return(invisible(NULL))
@@ -48,7 +48,7 @@ The possibilities for creating errors when using `attach()` are numerous.
 
 We do not support using right-hand assignment.
 
-```
+```r
 # Bad
 iris %>%
   dplyr::summarize(max_petal = max(Petal.Width)) -> results
@@ -64,7 +64,7 @@ lines).
 Do not rely on R's implicit return feature. It is better to be clear about your
 intent to `return()` an object.
 
-```
+```r
 # Good
 AddValues <- function(x, y) {
   return(x + y)
@@ -80,7 +80,7 @@ AddValues <- function(x, y) {
 
 Users should explicitly qualify namespaces for all external functions.
 
-```
+```r
 # Good
 purrr::map()
 ```

--- a/docguide/style.md
+++ b/docguide/style.md
@@ -502,7 +502,7 @@ $ bazel run :target -- --flag --foo=longlonglonglonglongvalue \
 If you need a code block within a list, make sure to indent it so as to not
 break the list:
 
-```markdown
+````markdown
 *   Bullet.
 
     ```c++
@@ -510,7 +510,7 @@ break the list:
     ```
 
 *   Next bullet.
-```
+````
 
 You can also create a nested code block with 4 spaces. Simply indent 4
 additional spaces from the list indentation:

--- a/objcguide.md
+++ b/objcguide.md
@@ -1375,7 +1375,7 @@ Code should avoid redundant property access. Prefer to assign a property value
 to a local variable when the property value is not expected to change and needs
 to be used multiple times.
 
-```objc
+```objectivec
 // GOOD:
 
 UIView *view = self.view;
@@ -1384,7 +1384,7 @@ UIScrollView *scrollView = self.scrollView;
 [scrollView.trailingAnchor constraintEqualToAnchor:view.trailingAnchor].active = YES;
 ```
 
-```objc
+```objectivec
 // AVOID:
 
 [self.scrollView.loadingAnchor constraintEqualToAnchor:self.view.loadingAnchor].active = YES;
@@ -1394,7 +1394,7 @@ UIScrollView *scrollView = self.scrollView;
 When repeatedly referencing chained property invocations, prefer to capture the
 repeated expression in a local variable:
 
-```objc
+```objectivec
 // AVOID:
 
 foo.bar.baz.field1 = 10;
@@ -1402,7 +1402,7 @@ foo.bar.baz.field2 = @"Hello";
 foo.bar.baz.field3 = 2.71828183;
 ```
 
-```objc
+```objectivec
 // GOOD:
 
 Baz *baz = foo.bar.baz;


### PR DESCRIPTION


This PR resolves issue #976 by standardizing Markdown fenced code block formatting, correcting nesting syntax, and adding missing language identifiers to improve documentation readability and syntax highlighting consistency.

### Changes Made

1. **R Guide (`Rguide.md`)**:
   - Added the missing `r` language identifiers to 5 fenced code blocks to enable correct syntax highlighting for R code examples.

2. **Style Guide (`docguide/style.md`)**:
   - Corrected nested fenced code block formatting in the "Nest codeblocks within lists" section. Used 4 backticks for the outer Markdown code block so that the nested 3-backtick C++ code block doesn't prematurely terminate it and break the parser.

3. **Objective-C Guide (`objcguide.md`)**:
   - Standardized 4 code blocks that were using the `objc` tag to use `objectivec` instead, ensuring consistency with the other 98 Objective-C code blocks in the document.

### Verification

- Audited all Markdown files in the repository using a custom Node.js Markdown parser to verify that all code blocks are cleanly formatted and contain standard, supported language identifiers.

